### PR TITLE
feat: add porcupine waker detector & add wakeword_rms_recorder

### DIFF
--- a/demo/record.py
+++ b/demo/record.py
@@ -27,8 +27,10 @@ def compute_rms(data):
 
 def record_audio():
     audio = pyaudio.PyAudio()
-    stream = audio.open(format=FORMAT, channels=CHANNELS, rate=RATE,
-                        input=True, input_device_index=MIC_IDX, frames_per_buffer=CHUNK)
+    stream = audio.open(
+        format=FORMAT, channels=CHANNELS, rate=RATE,
+        input=True, input_device_index=None,
+        frames_per_buffer=CHUNK)
 
     silent_chunks = 0
     audio_started = False
@@ -39,6 +41,7 @@ def record_audio():
         data = stream.read(CHUNK)
         frames.append(data)
         rms = compute_rms(data)
+        print(f"rms:{rms} silence threshold:{SILENCE_THRESHOLD}")
         if audio_started:
             if rms < SILENCE_THRESHOLD:
                 silent_chunks += 1
@@ -60,6 +63,7 @@ def record_audio():
         wf.setsampwidth(audio.get_sample_size(FORMAT))
         wf.setframerate(RATE)
         wf.writeframes(b''.join(frames))
+        wf.close()
 
 
 if __name__ == '__main__':

--- a/demo/record_webrtcvad.py
+++ b/demo/record_webrtcvad.py
@@ -37,15 +37,19 @@ def record_audio():
     vad.set_mode(1)  # 敏感度，0 到 3，0 最不敏感，3 最敏感
     triggered = False
     frames.clear()
-    ratio = 0.7
+    active_ratio = 0.7
+    silent_ratio = 0.8
+    frame_size = FRAME_SIZE
+    print(f"read audio frame size: {frame_size}")
     while True:
-        frame = stream.read(FRAME_SIZE)
+        frame = stream.read(frame_size)
         is_speech = vad.is_speech(frame, RATE)
         if not triggered:
             frames.append((frame, is_speech))
             tmp.append(frame)
             num_voiced = len([f for f, speech in frames if speech])
-            if num_voiced > ratio * frames.maxlen:
+            print(f"num_voiced {num_voiced}")
+            if num_voiced > active_ratio * frames.maxlen:
                 print("start recording...")
                 triggered = True
                 frames.clear()
@@ -53,7 +57,7 @@ def record_audio():
             frames.append((frame, is_speech))
             tmp.append(frame)
             num_unvoiced = len([f for f, speech in frames if not speech])
-            if num_unvoiced > ratio * frames.maxlen:
+            if num_unvoiced > silent_ratio * frames.maxlen:
                 print("stop recording...")
                 export_wav(tmp, './records/tmp_webrtcvad.wav')
                 break

--- a/demo/wakeword_porcupine.py
+++ b/demo/wakeword_porcupine.py
@@ -24,7 +24,7 @@ def get_defualt_instance():
 
 
 def get_custom_instance():
-    keywords = ["小黑"]
+    keywords = "小黑".split(',')
     porcupine = pvporcupine.create(
         access_key, keywords=keywords,
         model_path="./models/porcupine_params_zh.pv",

--- a/demo/wakeword_porcupine.py
+++ b/demo/wakeword_porcupine.py
@@ -1,0 +1,114 @@
+import itertools
+import os
+import collections
+import struct
+
+import pyaudio
+import pvporcupine
+import wave
+
+
+porcupine = None
+paud = None
+audio_stream = None
+
+access_key = os.environ.get("PORCUPINE_ACCESS_KEY")
+
+
+def get_defualt_instance():
+    keywords = "hey google,terminator,americano,computer,pico clock,hey siri,grasshopper,alexa,jarvis,bumblebee,hey barista,blueberry,ok google,grapefruit,picovoice,porcupine".split(
+        ',')
+    print(keywords)
+    porcupine = pvporcupine.create(access_key, keywords=keywords)
+    return porcupine, keywords
+
+
+def get_custom_instance():
+    keywords = ["小黑"]
+    porcupine = pvporcupine.create(
+        access_key, keywords=keywords,
+        model_path="./models/porcupine_params_zh.pv",
+        keyword_paths=["./models/小黑_zh_mac_v3_0_0.ppn"],
+    )
+    return porcupine, keywords
+
+
+def porcess_wakeword(porcupine, audio_buffer):
+    # Removing the wake word from the recording
+    samples_for_0_1_sec = int(porcupine.sample_rate * 0.1)
+    start_index = max(0, len(audio_buffer) - samples_for_0_1_sec)
+    print(
+        f"start_index {start_index}, samples_for_0_1_sec {samples_for_0_1_sec}")
+    temp_samples = collections.deque(
+        itertools.islice(audio_buffer, start_index, None)
+    )
+    audio_buffer.clear()
+    audio_buffer.extend(temp_samples)
+    return audio_buffer
+
+
+FORMAT = pyaudio.paInt16
+CHANNELS = 1
+RATE = 16000
+
+
+def export_wav(data, filename, sample_rate=RATE, channels=CHANNELS, sample_width=2):
+    wf = wave.open(filename, 'wb')
+    wf.setnchannels(channels)
+    wf.setsampwidth(sample_width)
+    wf.setframerate(sample_rate)
+    wf.writeframes(b''.join(data))
+    wf.close()
+
+
+try:
+    # porcupine = get_defualt_instance()
+    porcupine, keywords = get_custom_instance()
+    print(porcupine.sample_rate, porcupine.frame_length)
+    if porcupine.sample_rate != RATE:
+        raise ValueError(
+            'Sample rate of your device is not %d Hz' % RATE)
+
+    pre_recording_buffer_duration = 10.0
+    maxlen = int((porcupine.sample_rate // porcupine.frame_length) *
+                 pre_recording_buffer_duration)
+    print(f"audio_buffer maxlen: {maxlen}")
+    # ring buffer
+    audio_buffer = collections.deque(maxlen=maxlen)
+
+    paud = pyaudio.PyAudio()
+    audio_stream = paud.open(rate=porcupine.sample_rate, channels=1,
+                             format=pyaudio.paInt16, input=True,
+                             frames_per_buffer=porcupine.frame_length)
+    print("start recording")
+    while True:
+        read_audio_frames = audio_stream.read(porcupine.frame_length)
+        # print(type(keyword), len(keyword))
+        keyword = struct.unpack_from(
+            "h"*porcupine.frame_length, read_audio_frames)
+        # print(type(keyword), len(keyword))
+        keyword_index = porcupine.process(keyword)
+        if keyword_index >= 0:
+            print(
+                f"index {keyword_index} {keywords[keyword_index]} hotword detected, audio_buffer length {len(audio_buffer)}")
+
+            audio_buffer = porcess_wakeword(porcupine, audio_buffer)
+            print(f"audio_buffer length {len(audio_buffer)}")
+            export_wav(
+                audio_buffer,
+                './records/tmp_wakeword_porcupine.wav',
+                sample_rate=porcupine.sample_rate,
+                channels=CHANNELS,
+                sample_width=paud.get_sample_size(FORMAT),
+            )
+
+        audio_buffer.append(read_audio_frames)
+        # print(len(audio_buffer))
+
+finally:
+    if porcupine is not None:
+        porcupine.delete()
+    if audio_stream is not None:
+        audio_stream.close()
+    if paud is not None:
+        paud.terminate()

--- a/src/cmd/local-terminal-chat/generate_audio2audio.py
+++ b/src/cmd/local-terminal-chat/generate_audio2audio.py
@@ -31,11 +31,36 @@ def clear_console():
     os.system('clear' if os.name == 'posix' else 'cls')
 
 
+def initWakerEngine() -> interface.IDetector:
+    # waker
+    recorder_tag = os.getenv('RECORDER_TAG', "rms_recorder")
+    if "waker" not in recorder_tag:
+        return None
+
+    tag = os.getenv('WAKER_DETECTOR_TAG', "porcupine_wakeword")
+    wake_words = os.getenv('WAKE_WORDS', "小黑")
+    model_path = os.path.join(
+        MODELS_DIR, "porcupine_params_zh.pv")
+    keyword_paths = os.path.join(
+        MODELS_DIR, "小黑_zh_mac_v3_0_0.ppn")
+    kwargs = {}
+    kwargs["access_key"] = os.getenv('PORCUPINE_ACCESS_KEY', "")
+    kwargs["wake_words"] = wake_words
+    kwargs["keyword_paths"] = os.getenv(
+        'KEYWORD_PATHS', keyword_paths).split(',')
+    kwargs["model_path"] = os.getenv('MODEL_PATH', model_path)
+    engine = EngineFactory.get_engine_by_tag(
+        EngineClass, tag, **kwargs)
+    return engine
+
+
 def initRecorderEngine() -> interface.IRecorder:
     # recorder
-    tag = os.getenv('RECODER_TAG', "rms_recorder")
+    tag = os.getenv('RECORDER_TAG', "rms_recorder")
     kwargs = {}
-    kwargs["input_device_index"] = int(os.getenv('MIC_IDX', "1"))
+    input_device_index = os.getenv('MIC_IDX', None)
+    kwargs["input_device_index"] = None if input_device_index is None else int(
+        input_device_index)
     engine = EngineFactory.get_engine_by_tag(
         EngineClass, tag, **kwargs)
     logging.info(f"initRecorderEngine: {tag}, {engine}")
@@ -44,7 +69,7 @@ def initRecorderEngine() -> interface.IRecorder:
 
 def initVADEngine() -> interface.IDetector:
     # vad detector
-    tag = os.getenv('DETECTOR_TAG', "pyannote_vad")
+    tag = os.getenv('VAD_DETECTOR_TAG', "pyannote_vad")
     model_type = os.getenv(
         'VAD_MODEL_TYPE', 'segmentation-3.0')
     model_ckpt_path = os.path.join(
@@ -146,7 +171,8 @@ def loop_record(conn: multiprocessing.connection.Connection, e: threading.Event)
     recorder = initRecorderEngine()
     sid = uuid.uuid4()
     session = Session(**SessionCtx(sid).__dict__)
-    logging.info(f"loop_record starting with session: {session}")
+    session.ctx.waker = initWakerEngine()
+    logging.info(f"loop_record starting with session ctx: {session.ctx}")
     print("start loop_record...", flush=True, file=sys.stderr)
     while True:
         try:
@@ -164,9 +190,9 @@ def loop_record(conn: multiprocessing.connection.Connection, e: threading.Event)
             session.increment_chat_round()
 
             e.wait()
-        except Exception as e:
+        except Exception as ex:
             logging.warning(
-                f"loop_record Exception {e} sid:{session.ctx.client_id}")
+                f"loop_record Exception {ex} sid:{session.ctx.client_id}")
 
 
 def loop_play(conn: multiprocessing.connection.Connection, e: threading.Event):
@@ -185,7 +211,9 @@ def loop_play(conn: multiprocessing.connection.Connection, e: threading.Event):
                 llm_gen_segments = 0
             elif msg == "LLM_GENERATE_TEXT":
                 if llm_gen_segments == 0:
-                    print("\nbot >> ", end="", flush=True, file=sys.stderr)
+                    bot_name = session.ctx.state["bot_name"] if "bot_name" in session.ctx.state else "bot"
+                    print(f"\n{bot_name} >> ", end="",
+                          flush=True, file=sys.stderr)
                 print(recv_data.strip(), end="", flush=True, file=sys.stderr)
                 llm_gen_segments += 1
             elif msg == "LLM_GENERATE_DONE":
@@ -257,9 +285,9 @@ def loop_asr_llm_generate(asr: interface.IAsr, llm: interface.ILlm,
                 text_buffer.put_nowait(
                     ("LLM_GENERATE_TEXT", text, session))
             conn.send(("LLM_GENERATE_DONE", "", session))
-        except Exception as e:
+        except Exception as ex:
             conn.send(
-                ("BE_EXCEPTION", f"asr_llm_generate's exception: {e}", session))
+                ("BE_EXCEPTION", f"asr_llm_generate's exception: {ex}", session))
 
 
 def loop_tts_synthesize(
@@ -289,9 +317,9 @@ def loop_tts_synthesize(
             logging.debug(
                 f"tts_synthesize's consumption queue is empty after block {q_get_timeout}s")
             continue
-        except Exception as e:
+        except Exception as ex:
             conn.send(
-                ("BE_EXCEPTION", f"tts_synthesize's exception: {e}", session))
+                ("BE_EXCEPTION", f"tts_synthesize's exception: {ex}", session))
 
 
 def main():

--- a/src/cmd/local-terminal-chat/generate_audio2audio.py
+++ b/src/cmd/local-terminal-chat/generate_audio2audio.py
@@ -34,7 +34,7 @@ def clear_console():
 def initWakerEngine() -> interface.IDetector:
     # waker
     recorder_tag = os.getenv('RECORDER_TAG', "rms_recorder")
-    if "waker" not in recorder_tag:
+    if "wake" not in recorder_tag:
         return None
 
     tag = os.getenv('WAKER_DETECTOR_TAG', "porcupine_wakeword")

--- a/src/common/audio_stream.py
+++ b/src/common/audio_stream.py
@@ -1,8 +1,29 @@
 import logging
+import collections
 
 import pyaudio
 
 from src.common.types import AudioStreamArgs
+
+
+class RingBuffer(object):
+    """Ring buffer to hold audio from audio stream"""
+
+    def __init__(self, size=4096):
+        self._buf = collections.deque(maxlen=size)
+
+    def get_buf(self):
+        return self._buf
+
+    def extend(self, data):
+        """Adds data to the end of buffer"""
+        self._buf.extend(data)
+
+    def get(self):
+        """Retrieves data from the beginning of buffer and clears it"""
+        tmp = bytes(bytearray(self._buf))
+        self._buf.clear()
+        return tmp
 
 
 class AudioStream:
@@ -19,6 +40,9 @@ class AudioStream:
         self.args = args
         self.stream = None
         self.pyaudio_instance = pyaudio.PyAudio()
+        if self.args.input is True and self.args.input_device_index is None:
+            default_device = self.pyaudio_instance.get_default_input_device_info()
+            self.args.input_device_index = default_device['index']
 
     def open_stream(self):
         """Opens an audio stream."""

--- a/src/common/interface.py
+++ b/src/common/interface.py
@@ -46,6 +46,14 @@ class IDetector(ABC):
     def set_audio_data(self, audio_data):
         raise NotImplemented("must be implemented in the child class")
 
+    @abstractmethod
+    def get_sample_info(self):
+        raise NotImplemented("must be implemented in the child class")
+
+    @abstractmethod
+    def close(self):
+        raise NotImplemented("must be implemented in the child class")
+
 
 class IAsr(ABC):
     @abstractmethod

--- a/src/common/session.py
+++ b/src/common/session.py
@@ -8,6 +8,20 @@ class Session:
         self.file_counter = 0
         self.chat_round = 0
 
+    def __getstate__(self):
+        return {
+            "config": self.config,
+            "file_counter": self.file_counter,
+            "chat_round": self.chat_round,
+            "ctx": self.ctx
+        }
+
+    def __setstate__(self, state):
+        self.config = state["config"]
+        self.file_counter = state["file_counter"]
+        self.chat_round = state["chat_round"]
+        self.ctx = state["ctx"]
+
     def update_config(self, config_data):
         self.config.update(config_data)
 

--- a/src/common/session.py
+++ b/src/common/session.py
@@ -12,10 +12,12 @@ class Session:
         self.config.update(config_data)
 
     def append_audio_data(self, audio_data):
-        self.ctx.buffering_stragegy.insert(audio_data)
+        if self.ctx.buffering_strategy is not None:
+            self.ctx.buffering_strategy.insert(audio_data)
 
     def clear_buffer(self):
-        self.ctx.buffering_stragegy.clear()
+        if self.ctx.buffering_strategy is not None:
+            self.ctx.buffering_strategy.clear()
 
     def increment_file_counter(self):
         self.file_counter += 1
@@ -30,8 +32,22 @@ class Session:
         # @TODO: use burr work flow
         if self.ctx.on_session_start:
             self.ctx.on_session_start(self)
-        if self.ctx.buffering_stragegy:
-            self.ctx.buffering_stragegy.process_audio(self)
+        if self.ctx.buffering_strategy:
+            self.ctx.buffering_strategy.process_audio(self)
         if self.ctx.on_session_end:
             self.ctx.on_session_end(self)
         self.clear_buffer()
+
+    def close(self):
+        if hasattr(self.ctx.buffering_strategy, "close"):
+            self.ctx.buffering_strategy.close()
+        if hasattr(self.ctx.waker, "close"):
+            self.ctx.waker.close()
+        if hasattr(self.ctx.vad, "close"):
+            self.ctx.vad.close()
+        if hasattr(self.ctx.asr, "close"):
+            self.ctx.asr.close()
+        if hasattr(self.ctx.llm, "close"):
+            self.ctx.llm.close()
+        if hasattr(self.ctx.tts, "close"):
+            self.ctx.tts.close()

--- a/src/common/types.py
+++ b/src/common/types.py
@@ -38,9 +38,9 @@ class SessionCtx:
     client_id: str
     sampling_rate: int = 16000
     samples_width: int = 2
-    frames = bytearray()
+    read_audio_frames = bytes()
     state = dict()
-    buffering_stragegy: IBuffering = None
+    buffering_strategy: IBuffering = None
     waker: IDetector = None
     vad: IDetector = None
     asr: IAsr = None
@@ -72,7 +72,7 @@ class AudioStreamArgs:
     channels: int = CHANNELS
     rate: int = RATE
     frames_per_buffer: int = CHUNK
-    input_device_index: int = MIC_IDX
+    input_device_index: int = None
     output_device_index: int = None
     input: bool = False
     output: bool = False
@@ -83,7 +83,7 @@ class AudioRecoderArgs:
     format_: str = FORMAT
     channels: int = CHANNELS
     rate: int = RATE
-    input_device_index: int = MIC_IDX
+    input_device_index: int = None
     frames_per_buffer: int = CHUNK
 
 
@@ -125,14 +125,18 @@ INIT_WAKE_WORD_TIMEOUT = 5.0
 
 @dataclass
 class PorcupineDetectorArgs:
+    access_key: str = ""
+    keyword_paths: list[str] = None
+    model_path: str = None
+    library_path: str = None
     wake_words: str = ""
     wake_words_sensitivity: float = INIT_WAKE_WORDS_SENSITIVITY
-    wake_word_activation_delay: float = INIT_WAKE_WORD_ACTIVATION_DELAY
-    wake_word_timeout: float = INIT_WAKE_WORD_TIMEOUT
+    # wake_word_activation_delay: float = INIT_WAKE_WORD_ACTIVATION_DELAY
+    # wake_word_timeout: float = INIT_WAKE_WORD_TIMEOUT
     on_wakeword_detected: callable = None
-    on_wakeword_timeout: callable = None
-    on_wakeword_detection_start: callable = None
-    on_wakeword_detection_end: callable = None
+    # on_wakeword_timeout: callable = None
+    # on_wakeword_detection_start: callable = None
+    # on_wakeword_detection_end: callable = None
 
 
 @dataclass

--- a/src/common/types.py
+++ b/src/common/types.py
@@ -101,6 +101,7 @@ class AudioRecoderArgs:
     rate: int = RATE
     input_device_index: int = None
     frames_per_buffer: int = CHUNK
+    silence_timeout_s: int = 10
 
 
 @dataclass

--- a/src/common/types.py
+++ b/src/common/types.py
@@ -49,6 +49,22 @@ class SessionCtx:
     on_session_start: callable = None
     on_session_end: callable = None
 
+    def __getstate__(self):
+        return {
+            "client_id": self.client_id,
+            "sampling_rate": self.sampling_rate,
+            "samples_width": self.samples_width,
+            "read_audio_frames": self.read_audio_frames,
+            "state": self.state,
+        }
+
+    def __setstate__(self, state):
+        self.client_id = state["client_id"]
+        self.sampling_rate = state["sampling_rate"]
+        self.samples_width = state["samples_width"]
+        self.read_audio_frames = state["read_audio_frames"]
+        self.state = state["state"]
+
 
 # audio stream default configuration
 CHUNK = 1024

--- a/src/modules/speech/detector/__init__.py
+++ b/src/modules/speech/detector/__init__.py
@@ -1,2 +1,3 @@
 from . import pyannote
-# from . import porcupine, silero_vad, webrtc_vad
+from . import porcupine
+# from . import silero_vad, webrtc_vad

--- a/src/modules/speech/detector/porcupine.py
+++ b/src/modules/speech/detector/porcupine.py
@@ -64,9 +64,9 @@ class PorcupineWakeWordDetector(PorcupineDetector, IDetector):
 
         # If a wake word is detected
         if wakeword_index >= 0:
-            logging.debug(
-                f"index {wakeword_index} {self.args.wake_words[wakeword_index]} hotword detected, audio_buffer length {len(self.audio_buffer)}")
-            session.ctx.state['bot_name'] = self.args.wake_words[wakeword_index]
+            logging.info(
+                f"index {wakeword_index} {self.wake_words_list[wakeword_index]} hotword detected, audio_buffer length {len(self.audio_buffer)}")
+            session.ctx.state['bot_name'] = self.wake_words_list[wakeword_index]
             # Removing the wake word from the recording
             samples_for_0_1_sec = int(self.porcupine.sample_rate * 0.1)
             start_index = max(0, len(self.audio_buffer) - samples_for_0_1_sec)

--- a/src/modules/speech/detector/porcupine.py
+++ b/src/modules/speech/detector/porcupine.py
@@ -4,16 +4,21 @@ import logging
 import struct
 import time
 
-import pvporcupine
 
 from src.common.session import Session
 from src.common.interface import IDetector
 from src.common.types import PorcupineDetectorArgs
+from src.common.factory import EngineClass
 
 
-class PorcupineDetector:
-    def __init__(self, args: PorcupineDetectorArgs) -> None:
-        self.args = args
+class PorcupineDetector(EngineClass):
+    @classmethod
+    def get_args(cls, **kwargs) -> dict:
+        return {**PorcupineDetectorArgs().__dict__, **kwargs}
+
+    def __init__(self, **args) -> None:
+        import pvporcupine
+        self.args = PorcupineDetectorArgs(**args)
         if self.args.wake_words:
             self.wake_words_list = [
                 word.strip() for word in self.args.wake_words.lower().split(',')
@@ -23,36 +28,47 @@ class PorcupineDetector:
                 for _ in range(len(self.wake_words_list))
             ]
 
-            self.porcupine = pvporcupine.create(
+            self.porcupine: pvporcupine.Porcupine = pvporcupine.create(
+                access_key=self.args.access_key,
+                library_path=self.args.library_path,
+                model_path=self.args.model_path,
+                keyword_paths=self.args.keyword_paths,
                 keywords=self.wake_words_list,
                 sensitivities=sensitivity_list
             )
-            self.buffer_size = self.porcupine.frame_length
-            self.sample_rate = self.porcupine.sample_rate
+
+            logging.debug(
+                f"sample_rate: {self.porcupine.sample_rate},frame_length: {self.porcupine.frame_length}")
+
+    def get_sample_info(self):
+        return self.porcupine.sample_rate, self.porcupine.frame_length
 
     def set_audio_data(self, audio_data):
         self.audio_buffer = audio_data
 
+    def close(self):
+        self.porcupine and self.porcupine.delete()
 
-class PorcupineWakeWordDetector(IDetector, PorcupineDetector):
-    def __init__(self, args: PorcupineDetectorArgs) -> None:
-        super.__init__(args)
-        logging.debug(
-            "Porcupine wake word detection engine initialized successfully")
+
+class PorcupineWakeWordDetector(PorcupineDetector, IDetector):
+    TAG = "porcupine_wakeword"
 
     async def detect(self, session: Session):
         if len(self.args.wake_words) == 0:
             return
         pcm = struct.unpack_from(
-            "h" * self.buffer_size,
-            session.ctx.frames
+            "h" * self.porcupine.frame_length,
+            session.ctx.read_audio_frames,
         )
         wakeword_index = self.porcupine.process(pcm)
 
         # If a wake word is detected
         if wakeword_index >= 0:
+            logging.debug(
+                f"index {wakeword_index} {self.args.wake_words[wakeword_index]} hotword detected, audio_buffer length {len(self.audio_buffer)}")
+            session.ctx.state['bot_name'] = self.args.wake_words[wakeword_index]
             # Removing the wake word from the recording
-            samples_for_0_1_sec = int(self.sample_rate * 0.1)
+            samples_for_0_1_sec = int(self.porcupine.sample_rate * 0.1)
             start_index = max(0, len(self.audio_buffer) - samples_for_0_1_sec)
             temp_samples = collections.deque(
                 itertools.islice(self.audio_buffer, start_index, None)
@@ -61,4 +77,6 @@ class PorcupineWakeWordDetector(IDetector, PorcupineDetector):
             self.audio_buffer.extend(temp_samples)
 
             if self.args.on_wakeword_detected:
-                self.args.on_wakeword_detected()
+                self.args.on_wakeword_detected(session, self.audio_buffer)
+            return True
+        return False

--- a/src/modules/speech/detector/pyannote.py
+++ b/src/modules/speech/detector/pyannote.py
@@ -5,7 +5,7 @@ from pyannote.audio.core.io import AudioFile
 
 from src.common.session import Session
 from src.common.interface import IDetector
-from src.common.types import PyannoteDetectorArgs
+from src.common.types import PyannoteDetectorArgs, RATE, CHUNK
 from src.common.factory import EngineClass
 
 r"""
@@ -64,6 +64,12 @@ class PyannoteDetector(EngineClass):
         if isinstance(audio_data, AudioFile):
             self.args.vad_pyannote_audio = audio_data
 
+    def get_sample_info(self):
+        return RATE, CHUNK
+
+    def close(self):
+        pass
+
 
 class PyannoteVAD(PyannoteDetector, IDetector):
     r"""
@@ -78,7 +84,7 @@ class PyannoteVAD(PyannoteDetector, IDetector):
         self.pipeline = VoiceActivityDetection(segmentation=self.model)
         self.pipeline.instantiate(self.hyper_parameters)
 
-    async def detect(self, session: Session) -> None:
+    async def detect(self, session: Session):
         vad_res = self.pipeline(self.args.vad_pyannote_audio)
         # `vad_res` is a pyannote.core.Annotation instance containing speech regions
         vad_segments = []

--- a/test/modules/speech/detector/test_porcupine.py
+++ b/test/modules/speech/detector/test_porcupine.py
@@ -1,0 +1,101 @@
+import collections
+import os
+import asyncio
+import logging
+
+import unittest
+import pyaudio
+
+from src.common.utils.audio_utils import get_audio_segment
+from src.common.logger import Logger
+from src.common.factory import EngineFactory, EngineClass
+from src.common.session import Session
+from src.common.types import SessionCtx, TEST_DIR, MODELS_DIR, RECORDS_DIR
+from src.common.interface import IDetector
+import src.modules.speech.detector
+
+r"""
+python -m unittest test.modules.speech.detector.test_porcupine.TestPorcupineWakeWordDetector.test_detect
+"""
+
+
+class TestPorcupineWakeWordDetector(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tag = os.getenv('DETECTOR_TAG', "porcupine_wakeword")
+        cls.wake_words = os.getenv('WAKE_WORDS', "小黑")
+        audio_file = os.path.join(
+            RECORDS_DIR, f"tmp_wakeword_porcupine.wav")
+        model_path = os.path.join(
+            MODELS_DIR, "porcupine_params_zh.pv")
+        keyword_paths = os.path.join(
+            MODELS_DIR, "小黑_zh_mac_v3_0_0.ppn")
+        cls.access_key = os.getenv('PORCUPINE_ACCESS_KEY', "")
+        cls.audio_file = os.getenv('AUDIO_FILE', audio_file)
+        cls.model_path = os.getenv('MODEL_PATH', model_path)
+        cls.keyword_paths = os.getenv('KEYWORD_PATHS', keyword_paths)
+
+        Logger.init(logging.DEBUG, is_file=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        kwargs = {}
+        kwargs["access_key"] = self.access_key
+        kwargs["wake_words"] = self.wake_words
+        kwargs["model_path"] = self.model_path
+        kwargs["keyword_paths"] = self.keyword_paths.split(',')
+        print(kwargs)
+        self.detector: IDetector = EngineFactory.get_engine_by_tag(
+            EngineClass, self.tag, **kwargs)
+        self.session = Session(**SessionCtx(
+            "test_client_id", 16000, 2).__dict__)
+
+        sample_rate, frame_length = self.detector.get_sample_info()
+        print(sample_rate, frame_length)
+        pre_recording_buffer_duration = 10.0
+        maxlen = int((sample_rate // frame_length) *
+                     pre_recording_buffer_duration)
+        print(f"audio_buffer maxlen: {maxlen}")
+        # ring buffer
+        self.audio_buffer = collections.deque(maxlen=maxlen)
+        self.sample_rate, self.frame_length = sample_rate, frame_length
+
+    def tearDown(self):
+        self.detector.close()
+
+    def test_detect(self):
+        audio_segment = asyncio.run(get_audio_segment(self.audio_file))
+        self.assertEqual(audio_segment.frame_rate, 16000)
+        self.audio_buffer.append(audio_segment.raw_data)
+        self.session.ctx.read_audio_frames = audio_segment.raw_data
+        self.detector.set_audio_data(self.audio_buffer)
+        res = asyncio.run(
+            self.detector.detect(self.session))
+        logging.debug(res)
+        self.assertEqual(res, False)
+
+    def test_record_detect(self):
+        paud = pyaudio.PyAudio()
+        audio_stream = paud.open(rate=self.sample_rate, channels=1,
+                                 format=pyaudio.paInt16, input=True,
+                                 frames_per_buffer=self.frame_length)
+
+        audio_stream.start_stream()
+        logging.debug("start recording")
+        while True:
+            read_audio_frames = audio_stream.read(self.frame_length)
+            self.session.ctx.read_audio_frames = read_audio_frames
+            self.detector.set_audio_data(self.audio_buffer)
+            res = asyncio.run(
+                self.detector.detect(self.session))
+            logging.debug(res)
+            if res is True:
+                break
+            self.audio_buffer.append(read_audio_frames)
+
+        audio_stream.stop_stream()
+        audio_stream.close()
+        paud.terminate()

--- a/test/modules/speech/recorder/test_record.py
+++ b/test/modules/speech/recorder/test_record.py
@@ -4,15 +4,22 @@ import asyncio
 
 import unittest
 
+from src.common.interface import IDetector, IRecorder
 from src.common.logger import Logger
-from src.common.factory import EngineFactory
+from src.common.factory import EngineFactory, EngineClass
 from src.common.session import Session
 from src.common.utils import audio_utils
 from src.common.types import SessionCtx, TEST_DIR, MODELS_DIR, RECORDS_DIR, INT16_MAX_ABS_VALUE
-from src.modules.speech.recorder.record import EngineClass
+import src.modules.speech
 
 r"""
 python -m unittest test.modules.speech.recorder.test_record.TestRMSRecorder.test_record
+python -m unittest test.modules.speech.recorder.test_record.TestRMSRecorder.test_multi_record
+python -m unittest test.modules.speech.recorder.test_record.TestRMSRecorder.test_wakeword_rms_record
+
+RECODER_TAG=wakeword_rms_recorder python -m unittest test.modules.speech.recorder.test_record.TestRMSRecorder.test_record
+RECODER_TAG=wakeword_rms_recorder python -m unittest test.modules.speech.recorder.test_record.TestRMSRecorder.test_multi_record
+RECODER_TAG=wakeword_rms_recorder python -m unittest test.modules.speech.recorder.test_record.TestRMSRecorder.test_wakeword_rms_record
 """
 
 
@@ -20,23 +27,39 @@ class TestRMSRecorder(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tag = os.getenv('RECODER_TAG', "rms_recorder")
-        cls.input_device_index = os.getenv('MIC_IDX', "1")
-        Logger.init(logging.DEBUG)
+        cls.input_device_index = os.getenv('MIC_IDX', None)
+
+        cls.detector_tag = os.getenv('DETECTOR_TAG', "porcupine_wakeword")
+        cls.wake_words = os.getenv('WAKE_WORDS', "小黑")
+        audio_file = os.path.join(
+            RECORDS_DIR, f"tmp_wakeword_porcupine.wav")
+        model_path = os.path.join(
+            MODELS_DIR, "porcupine_params_zh.pv")
+        keyword_paths = os.path.join(
+            MODELS_DIR, "小黑_zh_mac_v3_0_0.ppn")
+        cls.access_key = os.getenv('PORCUPINE_ACCESS_KEY', "")
+        cls.audio_file = os.getenv('AUDIO_FILE', audio_file)
+        cls.model_path = os.getenv('MODEL_PATH', model_path)
+        cls.keyword_paths = os.getenv('KEYWORD_PATHS', keyword_paths)
+
+        Logger.init(logging.DEBUG, is_file=False)
 
     @classmethod
     def tearDownClass(cls):
         pass
 
     def setUp(self):
-        kwargs = {}
-        kwargs["input_device_index"] = int(self.input_device_index)
-        self.recorder = EngineFactory.get_engine_by_tag(
-            EngineClass, self.tag, **kwargs)
+        self.kwargs = {}
+        self.kwargs["input_device_index"] = None if self.input_device_index is None else int(
+            self.input_device_index)
+        self.recorder: IRecorder = EngineFactory.get_engine_by_tag(
+            EngineClass, self.tag, **self.kwargs)
         self.session = Session(**SessionCtx(
             "test_client_id").__dict__)
 
     def tearDown(self):
-        self.recorder.close()
+        self.recorder and self.recorder.close()
+        self.session.close()
 
     def test_record(self):
         frames = self.recorder.record_audio(self.session)
@@ -45,3 +68,40 @@ class TestRMSRecorder(unittest.TestCase):
         file_path = asyncio.run(audio_utils.save_audio_to_file(
             data, os.path.join(RECORDS_DIR, "test.wav")))
         print(file_path)
+
+    def test_multi_record(self):
+        frames = self.recorder.record_audio(self.session)
+        self.assertGreater(len(frames), 0)
+        data = b''.join(frames)
+        file_path = asyncio.run(audio_utils.save_audio_to_file(
+            data, os.path.join(RECORDS_DIR, "test.wav")))
+        print(file_path)
+
+        self.recorder2 = EngineFactory.get_engine_by_tag(
+            EngineClass, self.tag, **self.kwargs)
+        frames = self.recorder2.record_audio(self.session)
+        self.assertGreater(len(frames), 0)
+        data = b''.join(frames)
+        file_path = asyncio.run(audio_utils.save_audio_to_file(
+            data, os.path.join(RECORDS_DIR, "test2.wav")))
+        print(file_path)
+        self.recorder2.close()
+
+    def test_wakeword_rms_record(self):
+        kwargs = {}
+        kwargs["access_key"] = self.access_key
+        kwargs["wake_words"] = self.wake_words
+        kwargs["model_path"] = self.model_path
+        kwargs["keyword_paths"] = self.keyword_paths.split(',')
+        # print(kwargs)
+        self.session.ctx.waker = EngineFactory.get_engine_by_tag(
+            EngineClass, self.detector_tag, **kwargs)
+
+        round = 3
+        for i in range(round):
+            frames = self.recorder.record_audio(self.session)
+            self.assertGreater(len(frames), 0)
+            data = b''.join(frames)
+            file_path = asyncio.run(audio_utils.save_audio_to_file(
+                data, os.path.join(RECORDS_DIR, f"test{i}.wav")))
+            print(file_path)

--- a/test/modules/speech/recorder/test_record.py
+++ b/test/modules/speech/recorder/test_record.py
@@ -88,10 +88,14 @@ class TestRMSRecorder(unittest.TestCase):
         self.recorder2.close()
 
     def test_wakeword_rms_record(self):
+        def on_wakeword_detected(session, data):
+            print(
+                f"bot_name:{session.ctx.state['bot_name']} wakeword detected")
         kwargs = {}
         kwargs["access_key"] = self.access_key
         kwargs["wake_words"] = self.wake_words
         kwargs["model_path"] = self.model_path
+        kwargs["on_wakeword_detected"] = on_wakeword_detected
         kwargs["keyword_paths"] = self.keyword_paths.split(',')
         # print(kwargs)
         self.session.ctx.waker = EngineFactory.get_engine_by_tag(
@@ -100,7 +104,7 @@ class TestRMSRecorder(unittest.TestCase):
         round = 3
         for i in range(round):
             frames = self.recorder.record_audio(self.session)
-            self.assertGreater(len(frames), 0)
+            self.assertGreaterEqual(len(frames), 0)
             data = b''.join(frames)
             file_path = asyncio.run(audio_utils.save_audio_to_file(
                 data, os.path.join(RECORDS_DIR, f"test{i}.wav")))


### PR DESCRIPTION
feat:
- add porcupine waker detector , more detail see: https://picovoice.ai/docs/porcupine/
- add wakeword_rms_recorder engine
- local-terminal-chat generate cmd Integrated waker
- add rms recording with silence_timeout default 10s
- run local-terminal-chat.generate_audio2audio  `TQDM_DISABLE=True RECORDER_TAG=wakeword_rms_recorder python -m src.cmd.local-terminal-chat.generate_audio2audio > std_out.log`  with wake word rms recorder
