### PR TITLE
feat: add env init and save to yaml config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # chat-bot
+
+## audio (voice)
 - stream-stt (realtime-recorder)
+
 - audio-llm (multimode-chat)
 ![pipe](https://github.com/weedge/chat-bot/assets/1203957/08f731d5-af49-4038-a28c-6a493d926839)
 ![queue](https://github.com/weedge/chat-bot/assets/1203957/ff729a39-f6d2-44cc-87e3-e0756a8a1c8b)
 
 - stream-tts (realtime-(clone)-speaker)
 
-- more (Embodied Intelligence: Robots that touch the world and move)
+## vision (CV)
+- stream-ocr (realtime-object-dectection)
+
+# more
+- Embodied Intelligence: Robots that touch the world and move

--- a/demo/vad_silero.py
+++ b/demo/vad_silero.py
@@ -1,2 +1,4 @@
 r"""
+- https://github.com/snakers4/silero-vad
+- https://medium.com/axinc-ai/silerovad-machine-learning-model-to-detect-speech-segments-e99722c0dd41
 """

--- a/src/cmd/be.py
+++ b/src/cmd/be.py
@@ -1,15 +1,18 @@
-import multiprocessing
 import multiprocessing.connection
+import multiprocessing
+import threading
 import logging
 import asyncio
-import threading
 import queue
 import sys
+import os
 
 
-from src.common.session import Session
 from src.common import interface
-from src.cmd.init import Env as init
+if os.getenv("INIT_TYPE", 'env') == 'yaml_config':
+    from src.cmd.init import YamlConfig as init
+else:
+    from src.cmd.init import Env as init
 
 
 HISTORY_LIMIT = 10240

--- a/src/cmd/be.py
+++ b/src/cmd/be.py
@@ -9,7 +9,7 @@ import sys
 
 from src.common.session import Session
 from src.common import interface
-from src.cmd import init
+from src.cmd.init import Env as init
 
 
 HISTORY_LIMIT = 10240

--- a/src/cmd/fe.py
+++ b/src/cmd/fe.py
@@ -12,7 +12,10 @@ from src.common import interface
 from src.common.session import Session
 from src.common.utils.audio_utils import save_audio_to_file
 from src.common.types import SessionCtx, RECORDS_DIR
-from src.cmd.init import Env as init
+if os.getenv("INIT_TYPE", 'env') == 'yaml_config':
+    from src.cmd.init import YamlConfig as init
+else:
+    from src.cmd.init import Env as init
 
 
 class TerminalChatClient:

--- a/src/cmd/init.py
+++ b/src/cmd/init.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import sys
+from typing import (Any)
 
 import pyaudio
 
@@ -11,184 +12,217 @@ from src.common.types import MODELS_DIR, RECORDS_DIR, CHUNK
 import src.modules.speech
 import src.core.llm
 
+
 DEFAULT_SYSTEM_PROMPT = "你是一个中国人,请用中文回答。回答限制在1-5句话内。要友好、乐于助人且简明扼要。保持对话简短而甜蜜。只用纯文本回答，不要包含链接或其他附加内容。不要回复计算机代码以及数学公式。"
 
 
-def clear_console():
-    os.system('clear' if os.name == 'posix' else 'cls')
+class Env:
 
+    @staticmethod
+    def initWakerEngine() -> interface.IDetector | EngineClass:
+        # waker
+        recorder_tag = os.getenv('RECORDER_TAG', "rms_recorder")
+        if "wake" not in recorder_tag:
+            return None
 
-def on_wakeword_detected(session, data):
-    if "bot_name" in session.ctx.state:
-        print(f"{session.ctx.state['bot_name']}~ ",
-              end="", flush=True, file=sys.stderr)
+        tag = os.getenv('WAKER_DETECTOR_TAG', "porcupine_wakeword")
+        wake_words = os.getenv('WAKE_WORDS', "小黑")
+        model_path = os.path.join(
+            MODELS_DIR, "porcupine_params_zh.pv")
+        keyword_paths = os.path.join(
+            MODELS_DIR, "小黑_zh_mac_v3_0_0.ppn")
+        kwargs = {}
+        kwargs["access_key"] = os.getenv('PORCUPINE_ACCESS_KEY', "")
+        kwargs["wake_words"] = wake_words
+        kwargs["keyword_paths"] = os.getenv(
+            'KEYWORD_PATHS', keyword_paths).split(',')
+        kwargs["model_path"] = os.getenv('MODEL_PATH', model_path)
+        engine = EngineFactory.get_engine_by_tag(
+            EngineClass, tag, **kwargs)
+        return engine
 
+    @staticmethod
+    def initRecorderEngine() -> interface.IRecorder | EngineClass:
+        # recorder
+        tag = os.getenv('RECORDER_TAG', "rms_recorder")
+        kwargs = {}
+        input_device_index = os.getenv('MIC_IDX', None)
+        kwargs["input_device_index"] = None if input_device_index is None else int(
+            input_device_index)
+        engine = EngineFactory.get_engine_by_tag(
+            EngineClass, tag, **kwargs)
+        logging.info(f"initRecorderEngine: {tag}, {engine}")
+        return engine
 
-def initWakerEngine() -> interface.IDetector:
-    # waker
-    recorder_tag = os.getenv('RECORDER_TAG', "rms_recorder")
-    if "wake" not in recorder_tag:
-        return None
+    @staticmethod
+    def initVADEngine() -> interface.IDetector | EngineClass:
+        # vad detector
+        tag = os.getenv('VAD_DETECTOR_TAG', "pyannote_vad")
+        model_type = os.getenv(
+            'VAD_MODEL_TYPE', 'segmentation-3.0')
+        model_ckpt_path = os.path.join(
+            MODELS_DIR, 'pyannote', model_type, "pytorch_model.bin")
+        kwargs = {}
+        kwargs["path_or_hf_repo"] = os.getenv(
+            'VAD_PATH_OR_HF_REPO', model_ckpt_path)
+        kwargs["model_type"] = model_type
+        engine = EngineFactory.get_engine_by_tag(
+            EngineClass, tag, **kwargs)
+        logging.info(f"initVADEngine: {tag}, {engine}")
+        return engine
 
-    tag = os.getenv('WAKER_DETECTOR_TAG', "porcupine_wakeword")
-    wake_words = os.getenv('WAKE_WORDS', "小黑")
-    model_path = os.path.join(
-        MODELS_DIR, "porcupine_params_zh.pv")
-    keyword_paths = os.path.join(
-        MODELS_DIR, "小黑_zh_mac_v3_0_0.ppn")
-    kwargs = {}
-    kwargs["access_key"] = os.getenv('PORCUPINE_ACCESS_KEY', "")
-    kwargs["wake_words"] = wake_words
-    kwargs["keyword_paths"] = os.getenv(
-        'KEYWORD_PATHS', keyword_paths).split(',')
-    kwargs["model_path"] = os.getenv('MODEL_PATH', model_path)
-    kwargs["on_wakeword_detected"] = on_wakeword_detected
-    engine = EngineFactory.get_engine_by_tag(
-        EngineClass, tag, **kwargs)
-    return engine
+    @staticmethod
+    def initASREngine() -> interface.IAsr | EngineClass:
+        # asr
+        tag = os.getenv('ASR_TAG', "whisper_timestamped_asr")
+        kwargs = {}
+        kwargs["model_name_or_path"] = os.getenv(
+            'ASR_MODEL_NAME_OR_PATH', 'base')
+        kwargs["download_path"] = MODELS_DIR
+        kwargs["verbose"] = True
+        kwargs["language"] = "zh"
+        engine = EngineFactory.get_engine_by_tag(
+            EngineClass, tag, **kwargs)
+        logging.info(f"initASREngine: {tag}, {engine}")
+        return engine
 
+    @staticmethod
+    def create_phi3_prompt(history: list[str],
+                           system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+                           init_message: str = None):
+        prompt = f'<|system|>\n{system_prompt}</s>\n'
+        if init_message:
+            prompt += f"<|assistant|>\n{init_message}</s>\n"
 
-def initRecorderEngine() -> interface.IRecorder:
-    # recorder
-    tag = os.getenv('RECORDER_TAG', "rms_recorder")
-    kwargs = {}
-    input_device_index = os.getenv('MIC_IDX', None)
-    kwargs["input_device_index"] = None if input_device_index is None else int(
-        input_device_index)
-    engine = EngineFactory.get_engine_by_tag(
-        EngineClass, tag, **kwargs)
-    logging.info(f"initRecorderEngine: {tag}, {engine}")
-    return engine
+        return prompt + "".join(history) + "<|assistant|>"
 
+    @staticmethod
+    def create_prompt(history: list[str],  init_message: str = None):
+        system_prompt: str = os.getenv(
+            'LLM_SYSTEM_PROMPT', DEFAULT_SYSTEM_PROMPT)
+        if "phi-3" in os.getenv('LLM_MODEL_NAME', 'phi-3').lower():
+            return Env.create_phi3_prompt(history, system_prompt, init_message)
 
-def initVADEngine() -> interface.IDetector:
-    # vad detector
-    tag = os.getenv('VAD_DETECTOR_TAG', "pyannote_vad")
-    model_type = os.getenv(
-        'VAD_MODEL_TYPE', 'segmentation-3.0')
-    model_ckpt_path = os.path.join(
-        MODELS_DIR, 'pyannote', model_type, "pytorch_model.bin")
-    kwargs = {}
-    kwargs["path_or_hf_repo"] = os.getenv(
-        'VAD_PATH_OR_HF_REPO', model_ckpt_path)
-    kwargs["model_type"] = model_type
-    engine = EngineFactory.get_engine_by_tag(
-        EngineClass, tag, **kwargs)
-    logging.info(f"initVADEngine: {tag}, {engine}")
-    return engine
+        return ""
 
+    @staticmethod
+    def get_user_prompt(text):
+        if "phi-3" in os.getenv('LLM_MODEL_NAME', 'phi-3').lower():
+            return (f"<|user|>\n{text}</s>\n")
+        return ""
 
-def initASREngine() -> interface.IAsr:
-    # asr
-    tag = os.getenv('ASR_TAG', "whisper_timestamped_asr")
-    kwargs = {}
-    kwargs["model_name_or_path"] = os.getenv('ASR_MODEL_NAME_OR_PATH', 'base')
-    kwargs["download_path"] = MODELS_DIR
-    kwargs["verbose"] = True
-    kwargs["language"] = "zh"
-    engine = EngineFactory.get_engine_by_tag(
-        EngineClass, tag, **kwargs)
-    logging.info(f"initASREngine: {tag}, {engine}")
-    return engine
+    @staticmethod
+    def get_assistant_prompt(text):
+        if "phi-3" in os.getenv('LLM_MODEL_NAME', 'phi-3').lower():
+            return (f"<|assistant|>\n{text}</s>\n")
+        return ""
 
+    @staticmethod
+    def initLLMEngine() -> interface.ILlm | EngineClass:
+        # llm
+        tag = os.getenv('LLM_TAG', "llm_llamacpp")
+        kwargs = {}
+        kwargs["model_name"] = os.getenv('LLM_MODEL_NAME', 'phi-3')
+        kwargs["model_path"] = os.getenv('LLM_MODEL_PATH', os.path.join(
+            MODELS_DIR, "Phi-3-mini-4k-instruct-q4.gguf"))
+        kwargs["model_type"] = os.getenv('LLM_MODEL_TYPE', "chat")
+        kwargs["n_threads"] = os.cpu_count()
+        kwargs["verbose"] = True
+        kwargs["llm_stream"] = False
+        # if logger.getEffectiveLevel() != logging.DEBUG:
+        #    kwargs["verbose"] = False
+        kwargs['llm_stop'] = ["<|end|>", "</s>", "/s>",
+                              "</s", "<s>", "<|user|>", "<|assistant|>", "<|system|>"]
+        engine = EngineFactory.get_engine_by_tag(
+            EngineClass, tag, **kwargs)
+        logging.info(f"initLLMEngine: {tag}, {engine}")
+        return engine
 
-def create_phi3_prompt(history: list[str],
-                       system_prompt: str = DEFAULT_SYSTEM_PROMPT,
-                       init_message: str = None):
-    prompt = f'<|system|>\n{system_prompt}</s>\n'
-    if init_message:
-        prompt += f"<|assistant|>\n{init_message}</s>\n"
+    @staticmethod
+    def get_tts_coqui_args() -> dict:
+        kwargs = {}
+        kwargs["model_path"] = os.getenv('TTS_MODEL_PATH', os.path.join(
+            MODELS_DIR, "coqui/XTTS-v2"))
+        kwargs["conf_file"] = os.getenv(
+            'TTS_CONF_FILE', os.path.join(MODELS_DIR, "coqui/XTTS-v2/config.json"))
+        kwargs["reference_audio_path"] = os.getenv('TTS_REFERENCE_AUDIO_PATH', os.path.join(
+            RECORDS_DIR, "tmp.wav"))
+        return kwargs
 
-    return prompt + "".join(history) + "<|assistant|>"
+    def get_tts_chat_args() -> dict:
+        kwargs = {}
+        kwargs["local_path"] = os.getenv('LOCAL_PATH', os.path.join(
+            MODELS_DIR, "2Noise/ChatTTS"))
+        kwargs["source"] = os.getenv('TTS_CHAT_SOURCE', "local")
+        return kwargs
 
-
-def create_prompt(history: list[str],  init_message: str = None):
-    system_prompt: str = os.getenv('LLM_SYSTEM_PROMPT', DEFAULT_SYSTEM_PROMPT)
-    if "phi-3" in os.getenv('LLM_MODEL_NAME', 'phi-3').lower():
-        return create_phi3_prompt(history, system_prompt, init_message)
-
-    return ""
-
-
-def get_user_prompt(text):
-    if "phi-3" in os.getenv('LLM_MODEL_NAME', 'phi-3').lower():
-        return (f"<|user|>\n{text}</s>\n")
-    return ""
-
-
-def get_assistant_prompt(text):
-    if "phi-3" in os.getenv('LLM_MODEL_NAME', 'phi-3').lower():
-        return (f"<|assistant|>\n{text}</s>\n")
-    return ""
-
-
-def initLLMEngine() -> interface.ILlm:
-    # llm
-    tag = os.getenv('LLM_TAG', "llm_llamacpp")
-    kwargs = {}
-    kwargs["model_name"] = os.getenv('LLM_MODEL_NAME', 'phi-3')
-    kwargs["model_path"] = os.getenv('LLM_MODEL_PATH', os.path.join(
-        MODELS_DIR, "Phi-3-mini-4k-instruct-q4.gguf"))
-    kwargs["model_type"] = os.getenv('LLM_MODEL_TYPE', "chat")
-    kwargs["n_threads"] = os.cpu_count()
-    kwargs["verbose"] = True
-    kwargs["llm_stream"] = False
-    # if logger.getEffectiveLevel() != logging.DEBUG:
-    #    kwargs["verbose"] = False
-    kwargs['llm_stop'] = ["<|end|>", "</s>", "/s>",
-                          "</s", "<s>", "<|user|>", "<|assistant|>", "<|system|>"]
-    engine = EngineFactory.get_engine_by_tag(
-        EngineClass, tag, **kwargs)
-    logging.info(f"initLLMEngine: {tag}, {engine}")
-    return engine
-
-
-def get_tts_coqui_config() -> dict:
-    kwargs = {}
-    kwargs["model_path"] = os.getenv('TTS_MODEL_PATH', os.path.join(
-        MODELS_DIR, "coqui/XTTS-v2"))
-    kwargs["conf_file"] = os.getenv(
-        'TTS_CONF_FILE', os.path.join(MODELS_DIR, "coqui/XTTS-v2/config.json"))
-    kwargs["reference_audio_path"] = os.getenv('TTS_REFERENCE_AUDIO_PATH', os.path.join(
-        RECORDS_DIR, "tmp.wav"))
-    return kwargs
-
-
-def get_tts_chat_config() -> dict:
-    kwargs = {}
-    kwargs["local_path"] = os.getenv('LOCAL_PATH', os.path.join(
-        MODELS_DIR, "2Noise/ChatTTS"))
-    kwargs["source"] = os.getenv('TTS_CHAT_SOURCE', "local")
-    return kwargs
-
-
-# TAG : config
-map_config_func = {
-    'tts_coqui': get_tts_coqui_config,
-    'tts_chat': get_tts_chat_config,
-}
-
-
-def initTTSEngine() -> interface.ITts:
-    # tts
-    tag = os.getenv('TTS_TAG', "tts_chat")
-    kwargs = map_config_func[tag]()
-    engine = EngineFactory.get_engine_by_tag(
-        EngineClass, tag, **kwargs)
-    logging.info(f"initTTSEngine: {tag}, {engine}")
-    return engine
-
-
-def initPlayerEngine(tts: interface.ITts = None) -> interface.IPlayer:
-    # player
-    tag = os.getenv('PLAYER_TAG', "stream_player")
-    # info = tts.get_stream_info()
-    info = {
-        "format_": pyaudio.paFloat32,
-        "channels": 1,
-        "rate": 24000,
+    # TAG : config
+    map_config_func = {
+        'tts_coqui': get_tts_coqui_args,
+        'tts_chat': get_tts_chat_args,
     }
-    info["chunk_size"] = CHUNK * 10
-    engine = EngineFactory.get_engine_by_tag(EngineClass, tag, **info)
-    logging.info(f"stream_info: {info}, initPlayerEngine: {tag},  {engine}")
-    return engine
+
+    @staticmethod
+    def initTTSEngine() -> interface.ITts | EngineClass:
+        # tts
+        tag = os.getenv('TTS_TAG', "tts_chat")
+        kwargs = Env.map_config_func[tag]()
+        engine = EngineFactory.get_engine_by_tag(
+            EngineClass, tag, **kwargs)
+        logging.info(f"initTTSEngine: {tag}, {engine}")
+        return engine
+
+    @staticmethod
+    def initPlayerEngine(tts: interface.ITts = None) -> interface.IPlayer | EngineClass:
+        # player
+        tag = os.getenv('PLAYER_TAG', "stream_player")
+        # info = tts.get_stream_info()
+        info = {
+            "format_": pyaudio.paFloat32,
+            "channels": 1,
+            "rate": 24000,
+        }
+        info["chunk_size"] = CHUNK * 10
+        engine = EngineFactory.get_engine_by_tag(EngineClass, tag, **info)
+        logging.info(
+            f"stream_info: {info}, initPlayerEngine: {tag},  {engine}")
+        return engine
+
+    @staticmethod
+    def save_to_yaml_config(args: Any, file_path: str):
+        from omegaconf import OmegaConf
+        conf = OmegaConf.structured(args)
+        yaml_str = OmegaConf.to_yaml(conf)
+        with open(file_path, 'w') as f:
+            f.write(yaml_str)
+
+
+class Config:
+
+    @staticmethod
+    def initWakerEngine() -> interface.IDetector | EngineClass:
+        pass
+
+    @staticmethod
+    def initRecorderEngine() -> interface.IRecorder | EngineClass:
+        pass
+
+    @staticmethod
+    def initVADEngine() -> interface.IDetector | EngineClass:
+        pass
+
+    @staticmethod
+    def initASREngine() -> interface.IAsr | EngineClass:
+        pass
+
+    @staticmethod
+    def initLLMEngine() -> interface.ILlm | EngineClass:
+        pass
+
+    @staticmethod
+    def initTTSEngine() -> interface.ITts | EngineClass:
+        pass
+
+    @staticmethod
+    def initPlayerEngine(tts: interface.ITts = None) -> interface.IPlayer | EngineClass:
+        pass

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -1,0 +1,18 @@
+import logging
+
+
+class Conf:
+    @staticmethod
+    async def save_to_yaml(args, file_path: str):
+        from omegaconf import OmegaConf
+        conf = OmegaConf.create(args)
+        logging.debug(f"save config:{conf} to {file_path}")
+        yaml_str = OmegaConf.to_yaml(conf)
+        with open(file_path, 'w') as f:
+            f.write(yaml_str)
+
+    @staticmethod
+    async def load_from_yaml(file_path: str):
+        from omegaconf import OmegaConf
+        conf = OmegaConf.load(file_path)
+        return conf

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -1,4 +1,10 @@
 import logging
+import os
+import inspect
+import asyncio
+
+
+from .types import CONFIG_DIR
 
 
 class Conf:
@@ -10,6 +16,49 @@ class Conf:
         yaml_str = OmegaConf.to_yaml(conf)
         with open(file_path, 'w') as f:
             f.write(yaml_str)
+
+    @staticmethod
+    async def save_obj_to_yaml(name, obj, tag=None):
+        if "init" not in name and "Engine" not in name:
+            return
+        engine = obj()
+        if tag and tag not in engine.TAG:
+            return
+        # u can use local, dev, test, stress, gray, online
+        env = os.getenv('CONF_ENV', "env")
+        file_dir = os.path.join(CONFIG_DIR, env)
+        if not os.path.exists(file_dir):
+            os.makedirs(file_dir)
+        file_path = os.path.join(file_dir, f"{engine.TAG}.yaml")
+        logging.debug(f"obj: {obj}, engine: {engine}, file_path: {file_path}")
+        await Conf.save_to_yaml(engine.args.__dict__, file_path)
+        return name[4:len(name)-6].lower(), file_path, engine.TAG
+
+    @staticmethod
+    async def save_to_yamls(object, tag=None):
+        async_tasks = []
+        for name, obj in inspect.getmembers(object, inspect.isfunction):
+            async_task = asyncio.create_task(
+                Conf.save_obj_to_yaml(name, obj, tag))
+            async_tasks.append(async_task)
+            # await async_task
+        logging.debug(f"{async_tasks}, len(async_tasks):{len(async_tasks)}")
+        res = await asyncio.gather(*async_tasks, return_exceptions=True)
+        manifests = {}
+        items = []
+        for item in res:
+            if item is None:
+                continue
+            items.append(item)
+            name, file_path, _tag = item
+            manifests[name] = {"file_path": file_path, "tag": _tag}
+
+        env = os.getenv('CONF_ENV', "local")
+        file_path = os.path.join(CONFIG_DIR, env, "manifests.yaml")
+        await Conf.save_to_yaml(manifests, file_path)
+        items.append(("manifests", file_path, "manifests"))
+
+        return items
 
     @staticmethod
     async def load_from_yaml(file_path: str):

--- a/src/common/factory.py
+++ b/src/common/factory.py
@@ -8,8 +8,8 @@ class EngineClass(object):
     # the same as ABC(Abstract Base Classe)
     __metaclass__ = ABCMeta
 
-    # args
     args = None
+    TAG = ""
 
     @classmethod
     def get_args(cls, **kwargs) -> dict:

--- a/src/common/factory.py
+++ b/src/common/factory.py
@@ -8,9 +8,18 @@ class EngineClass(object):
     # the same as ABC(Abstract Base Classe)
     __metaclass__ = ABCMeta
 
+    # args
+    args = None
+
     @classmethod
     def get_args(cls, **kwargs) -> dict:
         return kwargs
+
+    def set_args(self, **args):
+        if self.args is not None \
+                and hasattr(self.args, '__dict__') \
+                and hasattr(self.args, '__class__'):
+            self.args = self.args.__class__(**{**self.args.__dict__, **args})
 
     @classmethod
     def get_instance(cls, **kwargs):

--- a/src/common/types.py
+++ b/src/common/types.py
@@ -2,8 +2,13 @@ r"""
 use SOTA LLM like chatGPT to generate config file(json,yaml,toml) from dataclass type
 """
 import os
-from typing import Union, List
 from dataclasses import dataclass
+from typing import (
+    Optional,
+    Sequence,
+    Union,
+    List
+)
 
 import numpy as np
 from pyannote.audio.core.io import AudioFile
@@ -143,17 +148,17 @@ INIT_WAKE_WORD_TIMEOUT = 5.0
 @dataclass
 class PorcupineDetectorArgs:
     access_key: str = ""
-    keyword_paths: list[str] = None
-    model_path: str = None
-    library_path: str = None
+    keyword_paths: Optional[Sequence[str]] = None
+    model_path: Optional[str] = None
+    library_path: Optional[str] = None
     wake_words: str = ""
     wake_words_sensitivity: float = INIT_WAKE_WORDS_SENSITIVITY
     # wake_word_activation_delay: float = INIT_WAKE_WORD_ACTIVATION_DELAY
     # wake_word_timeout: float = INIT_WAKE_WORD_TIMEOUT
-    on_wakeword_detected: callable = None
-    # on_wakeword_timeout: callable = None
-    # on_wakeword_detection_start: callable = None
-    # on_wakeword_detection_end: callable = None
+    on_wakeword_detected: Optional[str] = None
+    # on_wakeword_timeout: Optional[str] = None
+    # on_wakeword_detection_start: Optional[str] = None
+    # on_wakeword_detection_end: Optional[str] = None
 
 
 @dataclass
@@ -166,7 +171,7 @@ class WhisperASRArgs:
     # - transformers whisper use torch tensor/tf tensor
     # - faster whisper don't use torch tensor, use np.ndarray or str(file_path)/~BinaryIO~
     # - mlx whisper don't use torch tensor, use str(file_path)/np.ndarray/~mlx.array~
-    asr_audio: Union[str, np.ndarray, torch.Tensor] = None
+    asr_audio: str | np.ndarray | torch.Tensor = None
     language: str = "zh"
     verbose: bool = True
 
@@ -204,7 +209,7 @@ class LLamcppLLMArgs:
     verbose: bool = True
     # llm
     llm_prompt_tpl: str = "<|user|>\n{%s}<|end|>\n<|assistant|>"
-    llm_stop: Union[str, List[str]] = None
+    llm_stop: Optional[List[str]] = None
     llm_max_tokens: int = 256
     llm_temperature: float = 0.8
     llm_top_p: float = 0.95

--- a/src/common/utils/task.py
+++ b/src/common/utils/task.py
@@ -5,6 +5,10 @@ from typing import Callable, Any
 
 
 async def async_task(sync_func: Callable, *args, **kwargs) -> Any:
+    """
+    https://docs.python.org/3.11/library/asyncio-eventloop.html#asyncio.loop.run_in_executor
+    """
     loop = asyncio.get_event_loop()
     with ThreadPoolExecutor() as pool:
+        # Futures
         return await loop.run_in_executor(pool, sync_func, *args, **kwargs)

--- a/src/modules/speech/tts/chat_tts.py
+++ b/src/modules/speech/tts/chat_tts.py
@@ -43,9 +43,10 @@ class ChatTTS(BaseTTS, ITts):
             **kwargs
         ):
         """
+        self.rand_speaker = self.chat.sample_random_speaker()
         self.args.params_infer_code = {
             # Sample a speaker from Gaussian.
-            'spk_emb': self.chat.sample_random_speaker(),
+            'spk_emb': None,
             'temperature': 0.3,
             'top_P': 0.7,
             'top_K': 20,
@@ -85,8 +86,8 @@ class ChatTTS(BaseTTS, ITts):
         }
 
     def _inference(self, session: Session, text: str) -> Iterator[bytes]:
-        logging.debug(
-            f"{self.TAG} synthesis: {text}")
+        self.set_speaker(self.rand_speaker)
+        logging.debug(f"{self.TAG} synthesis: {text}")
         wav = self.chat.infer(
             [text,],
             skip_refine_text=self.args.skip_refine_text,

--- a/test/cmd/test_init.py
+++ b/test/cmd/test_init.py
@@ -1,0 +1,38 @@
+import os
+import asyncio
+import logging
+
+import unittest
+
+from src.cmd.init import Env
+from src.common.logger import Logger
+
+r"""
+python -m unittest test.cmd.test_init.TestEnv.test_save_to_yaml
+"""
+
+
+class TestEnv(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        Logger.init(logging.DEBUG, is_file=False)
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_save_to_yaml(self):
+        os.environ['RECORDER_TAG'] = 'wakeword_rms_recorder'
+        os.environ['CONF_ENV'] = 'local'
+        res = asyncio.run(Env.save_to_yaml())
+        self.assertIsInstance(res, list)
+        for file_path in res:
+            print(file_path)
+            self.assertIsNotNone(file_path)

--- a/test/cmd/test_init.py
+++ b/test/cmd/test_init.py
@@ -8,7 +8,7 @@ from src.cmd.init import Env
 from src.common.logger import Logger
 
 r"""
-python -m unittest test.cmd.test_init.TestEnv.test_save_to_yaml
+python -m unittest test.cmd.test_init.TestEnv.test_save_to_yamls
 """
 
 
@@ -28,10 +28,10 @@ class TestEnv(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_save_to_yaml(self):
+    def test_save_to_yamls(self):
         os.environ['RECORDER_TAG'] = 'wakeword_rms_recorder'
         os.environ['CONF_ENV'] = 'local'
-        res = asyncio.run(Env.save_to_yaml())
+        res = asyncio.run(Env.save_to_yamls())
         self.assertIsInstance(res, list)
         for file_path in res:
             print(file_path)

--- a/test/modules/speech/recorder/test_record.py
+++ b/test/modules/speech/recorder/test_record.py
@@ -95,13 +95,14 @@ class TestRMSRecorder(unittest.TestCase):
         kwargs["access_key"] = self.access_key
         kwargs["wake_words"] = self.wake_words
         kwargs["model_path"] = self.model_path
-        kwargs["on_wakeword_detected"] = on_wakeword_detected
+        # kwargs["on_wakeword_detected"] = on_wakeword_detected
         kwargs["keyword_paths"] = self.keyword_paths.split(',')
-        # print(kwargs)
         self.session.ctx.waker = EngineFactory.get_engine_by_tag(
             EngineClass, self.detector_tag, **kwargs)
+        self.session.ctx.waker.set_args(
+            on_wakeword_detected=on_wakeword_detected)
 
-        round = 3
+        round = 1
         for i in range(round):
             frames = self.recorder.record_audio(self.session)
             self.assertGreaterEqual(len(frames), 0)


### PR DESCRIPTION
feat: 
- add env init and save to yaml config
- gen yaml config from env
- add `CONF_ENV=local python -m src.cmd.init` gen local init yaml config
- add concurrency load configs and gen configs, add below init cmd  run:
    - CONF_ENV=local python -m src.cmd.init -o init_engine -i env
    - CONF_ENV=local python -m src.cmd.init -o env2yaml
    - CONF_ENV=local python -m src.cmd.init -o init_engine -i config
    - CONF_ENV=local python -m src.cmd.init -o gather_load_configs
- use INIT_TYPE=yaml_config to init from yaml config