### PR TITLE
fix: remote-queue-chat

### DIFF
--- a/src/cmd/fe.py
+++ b/src/cmd/fe.py
@@ -19,16 +19,21 @@ else:
 
 
 class TerminalChatClient:
-    def __init__(self) -> None:
+    def __init__(self, is_save_record=False, is_save_play_chunks=False) -> None:
         self.sid = uuid.uuid4()
         self.session = Session(**SessionCtx(self.sid).__dict__)
         self.player = init.initPlayerEngine()
         self.recorder = init.initRecorderEngine()
         self.waker = init.initWakerEngine()
         self.start_record_event = threading.Event()
+        self.play_chunks = []
+        self.is_save_play_chunks = is_save_play_chunks
+        self.is_save_record = is_save_record
 
     def run(self, conn: interface.IConnector):
-        self.player.set_args(on_play_end=self.on_play_end)
+        if self.is_save_play_chunks:
+            self.player.set_args(on_play_chunk=self.on_play_chunk,
+                                 on_play_end=self.on_play_end)
         self.player.start(self.session)
 
         play_t = threading.Thread(target=self.loop_recv,
@@ -48,10 +53,26 @@ class TerminalChatClient:
                   end="", flush=True, file=sys.stderr)
 
     def on_play_end(self, session: Session):
-        logging.info(f"play end with session.ctx.state {session.ctx.state}")
+        sample_info = init.get_stream_info()
+        # @todo: need async save i/o
+        asyncio.run(save_audio_to_file(
+            b''.join(self.play_chunks),
+            self.session.get_paly_audio_name(),
+            sample_rate=sample_info["rate"],
+            channles=sample_info["channels"],
+            sample_width=sample_info["sample_width"],
+            audio_dir=RECORDS_DIR))
+        logging.info(
+            f"play end with session.ctx {session.ctx}, saved chunks_len {len(self.play_chunks)}")
+
+    def on_play_chunk(self, session: Session, sub_chunk: bytes):
+        logging.info(
+            f"play chunk with session.ctx {session.ctx}, sub_chunk_len {len(sub_chunk)}")
+        self.play_chunks.append(sub_chunk)
 
     def loop_record(self, conn: interface.IConnector):
-        self.waker.set_args(on_wakeword_detected=self.on_wakeword_detected)
+        if self.waker is not None:
+            self.waker.set_args(on_wakeword_detected=self.on_wakeword_detected)
         logging.info(
             f"loop_record starting with session ctx: {self.session.ctx}")
         print(
@@ -72,9 +93,10 @@ class TerminalChatClient:
                     continue
                 data = b''.join(frames)
                 conn.send(("RECORD_FRAMES", data, self.session), 'fe')
-                asyncio.run(save_audio_to_file(
-                    data, self.session.get_file_name(), audio_dir=RECORDS_DIR))
-                self.session.increment_file_counter()
+                if self.is_save_record:
+                    asyncio.run(save_audio_to_file(
+                        data, self.session.get_record_audio_name(),
+                        audio_dir=RECORDS_DIR))
                 self.session.increment_chat_round()
 
                 if self.start_record_event.is_set():
@@ -96,9 +118,27 @@ class TerminalChatClient:
                 if res is None:
                     continue
 
-                msg, recv_data, self.session = res
+                msg, recv_data, session = res
                 if msg is None or msg.lower() == "stop":
                     break
+                if isinstance(recv_data, str):
+                    logging.info(
+                        f'FE Received: {msg} recv_data: {recv_data}, session: {session}')
+                else:
+                    logging.info(
+                        f'FE Received: {msg} len(recv_data): {len(recv_data)}, session: {session}')
+
+                if msg == "BE_EXCEPTION":
+                    print(f"\nBE exception: {recv_data.strip()}",
+                          end="", flush=True, file=sys.stderr)
+                    self.start_record_event.set()
+                    llm_gen_segments = 0
+                    continue
+
+                if session.ctx.client_id != self.session.ctx.client_id:
+                    logging.warning(
+                        f"session.ctx.client_id: {session.ctx.client_id} != self.session.ctx.client_id: {self.session.ctx.client_id}")
+                    continue
 
                 if msg == "PLAY_FRAMES":
                     self.session.ctx.state["tts_chunk"] = recv_data
@@ -125,11 +165,6 @@ class TerminalChatClient:
                           flush=True, file=sys.stderr)
                 elif msg == "ASR_TEXT_DONE":
                     print("\n", end="", flush=True, file=sys.stderr)
-                elif msg == "BE_EXCEPTION":
-                    print(f"\nBE exception: {recv_data.strip()}",
-                          end="", flush=True, file=sys.stderr)
-                    self.start_record_event.set()
-                    llm_gen_segments = 0
                 else:
                     logging.warning(f"unsupport msg {msg}")
             except Exception as ex:

--- a/src/cmd/remote-queue-chat/generate_audio2audio.py
+++ b/src/cmd/remote-queue-chat/generate_audio2audio.py
@@ -2,6 +2,8 @@ import os
 import logging
 import argparse
 
+import uuid
+
 from src.cmd.fe import TerminalChatClient
 from src.cmd.be import Audio2AudioChatWorker as ChatWorker
 from src.common.connector.redis_queue import RedisQueueConnector
@@ -25,15 +27,15 @@ Logger.init(logging.INFO, is_file=True, is_console=False)
 
 def main():
     conn = RedisQueueConnector(
+        send_key=os.getenv("SEND_KEY", "SEND"),
         host=os.getenv(
             "REDIS_HOST",
             "redis-12259.c240.us-east-1-3.ec2.redns.redis-cloud.com"),
         port=os.getenv("REDIS_PORT", "12259"))
 
     op = os.getenv("RUN_OP", "fe")
-    if op == "be":
+    if op == "fe":
         client = TerminalChatClient()
-        conn.send_key = client.sid
         client.run(conn)
     else:
         ChatWorker().run(conn)

--- a/src/common/connector/redis_queue.py
+++ b/src/common/connector/redis_queue.py
@@ -1,5 +1,6 @@
 import asyncio
 import pickle
+import logging
 
 from src.common.interface import IConnector
 from src.common.queue.redis import RedisQueue

--- a/src/common/queue/redis.py
+++ b/src/common/queue/redis.py
@@ -25,9 +25,6 @@ class RedisQueue:
     async def get(self, key: str, timeout_s=0) -> bytes:
         key = self._get_key(key)
         logging.debug(f"get key: {key}")
-        q_len = self.client.llen(key)
-        if q_len > 10:
-            self.client.expire(key, 1)
         res = self.client.blpop(key, timeout=timeout_s)
         if res is None:
             return None

--- a/src/common/session.py
+++ b/src/common/session.py
@@ -5,7 +5,6 @@ class Session:
     def __init__(self, **args) -> None:
         self.ctx = SessionCtx(**args)
         self.config = {}
-        self.file_counter = 0
         self.chat_round = 0
         # just for local history,@todo: use kv store history
         self.chat_history = []
@@ -13,7 +12,6 @@ class Session:
     def __getstate__(self):
         return {
             "config": self.config,
-            "file_counter": self.file_counter,
             "chat_round": self.chat_round,
             "chat_history": self.chat_history,
             "ctx": self.ctx
@@ -21,10 +19,19 @@ class Session:
 
     def __setstate__(self, state):
         self.config = state["config"]
-        self.file_counter = state["file_counter"]
         self.chat_round = state["chat_round"]
         self.chat_history = state["chat_history"]
         self.ctx = state["ctx"]
+
+    def __repr__(self) -> str:
+        d = {
+            "config": self.config,
+            "chat_round": self.chat_round,
+            "chat_history": self.chat_history,
+            "ctx": self.ctx
+        }
+        s = f"session: {d}"
+        return s
 
     def update_config(self, config_data):
         self.config.update(config_data)
@@ -37,14 +44,14 @@ class Session:
         if self.ctx.buffering_strategy is not None:
             self.ctx.buffering_strategy.clear()
 
-    def increment_file_counter(self):
-        self.file_counter += 1
-
     def increment_chat_round(self):
         self.chat_round += 1
 
-    def get_file_name(self):
-        return f"{self.file_counter}_{self.ctx.client_id}.wav"
+    def get_record_audio_name(self):
+        return f"record_{self.chat_round}_{self.ctx.client_id}.wav"
+
+    def get_paly_audio_name(self):
+        return f"play_{self.chat_round}_{self.ctx.client_id}.wav"
 
     def process_audio(self):
         if self.ctx.on_session_start:

--- a/src/common/types.py
+++ b/src/common/types.py
@@ -38,12 +38,19 @@ TEST_DIR = os.path.normpath(
     os.path.join(SRC_PATH, os.pardir, "test")
 )
 
+# audio stream default configuration
+CHUNK = 1024
+FORMAT = pyaudio.paInt16
+CHANNELS = 1
+RATE = 16000
+SAMPLE_WIDTH = 2
+
 
 @dataclass
 class SessionCtx:
     client_id: str
-    sampling_rate: int = 16000
-    samples_width: int = 2
+    sampling_rate: int = RATE
+    sample_width: int = SAMPLE_WIDTH
     read_audio_frames = bytes()
     state = dict()
     buffering_strategy: IBuffering = None
@@ -55,11 +62,26 @@ class SessionCtx:
     on_session_start: callable = None
     on_session_end: callable = None
 
+    def __repr__(self) -> str:
+        d = {
+            "client_id": self.client_id,
+            "sampling_rate": self.sampling_rate,
+            "sample_width": self.sample_width,
+            "read_audio_frames_len": len(self.read_audio_frames),
+            "state": self.state,
+        }
+        if "tts_chunk" in self.state:
+            d['state']["tts_chunk_len"] = len(self.state['tts_chunk'])
+            d['state'].pop("tts_chunk")
+
+        res = f"session ctx: {d}"
+        return res
+
     def __getstate__(self):
         return {
             "client_id": self.client_id,
             "sampling_rate": self.sampling_rate,
-            "samples_width": self.samples_width,
+            "sample_width": self.sample_width,
             "read_audio_frames": self.read_audio_frames,
             "state": self.state,
         }
@@ -67,16 +89,10 @@ class SessionCtx:
     def __setstate__(self, state):
         self.client_id = state["client_id"]
         self.sampling_rate = state["sampling_rate"]
-        self.samples_width = state["samples_width"]
+        self.sample_width = state["sample_width"]
         self.read_audio_frames = state["read_audio_frames"]
         self.state = state["state"]
 
-
-# audio stream default configuration
-CHUNK = 1024
-FORMAT = pyaudio.paInt16
-CHANNELS = 1
-RATE = 16000
 
 # audio recorder default configuration
 SILENCE_THRESHOLD = 500
@@ -93,6 +109,7 @@ class AudioStreamArgs:
     format_: str = FORMAT
     channels: int = CHANNELS
     rate: int = RATE
+    sample_width: int = SAMPLE_WIDTH
     frames_per_buffer: int = CHUNK
     input_device_index: int = None
     output_device_index: int = None
@@ -105,6 +122,7 @@ class AudioRecoderArgs:
     format_: str = FORMAT
     channels: int = CHANNELS
     rate: int = RATE
+    sample_width: int = SAMPLE_WIDTH
     input_device_index: int = None
     frames_per_buffer: int = CHUNK
     silence_timeout_s: int = 10
@@ -115,6 +133,7 @@ class AudioPlayerArgs:
     format_: str = FORMAT
     channels: int = CHANNELS
     rate: int = RATE
+    sample_width: int = SAMPLE_WIDTH
     output_device_index: int = None
     sub_chunk_size: int = CHUNK
     audio_buffer: queue.Queue = None

--- a/src/core/llm/llamacpp.py
+++ b/src/core/llm/llamacpp.py
@@ -104,8 +104,8 @@ class LLamacppLLM(BaseLLM, ILlm):
             yield res
 
     def _have_special_char(self, content: str) -> int:
-        pattern = r'[.。,，;；!！?？]'
+        pattern = r"""[.。,，;；!！?？]"""
         matches = re.findall(pattern, content)
         if len(matches) == 0:
             return -1
-        return content.index(matches[0])
+        return content.index(matches[len(matches) - 1])

--- a/src/modules/speech/buffering_strategy/silence_end_chunk.py
+++ b/src/modules/speech/buffering_strategy/silence_end_chunk.py
@@ -33,7 +33,7 @@ class SilenceAtEndOfChunk(IBuffering):
 
     def process_audio(self, session: Session):
         chunk_length_in_bytes = self.chunk_length_seconds * \
-            session.ctx.sampling_rate * session.ctx.samples_width
+            session.ctx.sampling_rate * session.ctx.sample_width
         if len(self.buffer) > chunk_length_in_bytes:
             if self.processing_flag:
                 exit("Error in realtime processing: tried processing a new chunk while the previous one was still being processed")
@@ -49,7 +49,7 @@ class SilenceAtEndOfChunk(IBuffering):
                 or len(session.ctx.state["vad_res"]) == 0:
             return False
         last_segment_should_end_before = ((len(self.scratch_buffer) / (
-            session.ctx.sampling_rate * session.ctx.samples_width))
+            session.ctx.sampling_rate * session.ctx.sample_width))
             - self.chunk_offset_seconds)
         return session.ctx.state["vad_res"][-1]['end'] < last_segment_should_end_before
 

--- a/src/modules/speech/tts/base.py
+++ b/src/modules/speech/tts/base.py
@@ -1,10 +1,11 @@
 import asyncio
+import logging
+import re
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
 from typing import AsyncGenerator, Iterator, Generator
 
 import pyaudio
-
 
 from src.common.factory import EngineClass
 from src.common.session import Session
@@ -39,7 +40,7 @@ class BaseTTS(EngineClass):
         if hasattr(self.args, "chunk_length_seconds"):
             chunk_length_seconds = self.args.chunk_length_seconds
         chunk_length_in_bytes = chunk_length_seconds * \
-            stream_info["rate"] * stream_info["samples_width"]
+            stream_info["rate"] * stream_info["sample_width"]
 
         queue: Queue = Queue()
         with ThreadPoolExecutor() as executor:
@@ -62,6 +63,9 @@ class BaseTTS(EngineClass):
     async def synthesize(self, session: Session) -> AsyncGenerator[bytes, None]:
         if "tts_text_iter" in session.ctx.state:
             for text in session.ctx.state["tts_text_iter"]:
+                text: str = self.filter_special_chars(text)
+                if len(text.strip()) == 0:
+                    continue
                 async for chunk in self._inference(session, text):
                     yield chunk
                 silence_chunk = self._get_end_silence_chunk(session, text)
@@ -69,11 +73,13 @@ class BaseTTS(EngineClass):
                     yield silence_chunk
         elif "tts_text" in session.ctx.state:
             text = session.ctx.state["tts_text"]
-            async for chunk in self._inference(session, text):
-                yield chunk
-            silence_chunk = self._get_end_silence_chunk(session, text)
-            if silence_chunk:
-                yield silence_chunk
+            text = self.filter_special_chars(text)
+            if len(text.strip()) > 0:
+                async for chunk in self._inference(session, text):
+                    yield chunk
+                silence_chunk = self._get_end_silence_chunk(session, text)
+                if silence_chunk:
+                    yield silence_chunk
 
     async def _inference(self, session: Session, text: str) -> AsyncGenerator[bytes, None]:
         raise NotImplementedError(
@@ -87,5 +93,28 @@ class BaseTTS(EngineClass):
             "format_": pyaudio.paInt16,
             "channels": 1,
             "rate": 22050,
-            "samples_width": 2,
+            "sample_width": 2,
         }
+
+    def filter_special_chars(self, text: str) -> str:
+        # @TODO: use nlp stream process sentence
+        special_chars = ".。,，;；!！?？」>》}\\]】)~"
+        return self._filter_special_chars(special_chars, text)
+
+    def remove_trailing_special_chars(self, special_chars: str, s: str) -> str:
+        pattern = rf'(.*?)([{special_chars}])[{special_chars}]*$'
+        return re.sub(pattern, r'\1\2', s)
+
+    def _filter_special_chars(self, special_chars: str, text: str) -> str:
+        pattern = rf'[{special_chars}]'
+        match = re.search(pattern, text)
+        res = text
+        if match:
+            first_special_index = match.start()
+            res = text[:first_special_index + 1] + \
+                re.sub(rf'[{special_chars}]+$', '', text[first_special_index + 1:])
+            if len(res) == 1:  # have a special char, return empty
+                res = ""
+        res = res.strip('\n')
+        logging.debug(f"text:{text} --filter--> res:{res} with match:{match}")
+        return res

--- a/src/modules/speech/tts/chat_tts.py
+++ b/src/modules/speech/tts/chat_tts.py
@@ -83,7 +83,7 @@ class ChatTTS(BaseTTS, ITts):
             "format_": pyaudio.paFloat32,
             "channels": 1,
             "rate": 24000,
-            "samples_width": 4,
+            "sample_width": 4,
         }
 
     async def _inference(self, session: Session, text: str) -> AsyncGenerator[bytes, None]:

--- a/src/modules/speech/tts/coqui_tts.py
+++ b/src/modules/speech/tts/coqui_tts.py
@@ -74,7 +74,7 @@ class CoquiTTS(BaseTTS, ITts):
             "format_": pyaudio.paFloat32,
             "channels": 1,
             "rate": self.config.audio.output_sample_rate,
-            "samples_width": 4,
+            "sample_width": 4,
         }
 
     async def _inference(self, session: Session, text: str) -> AsyncGenerator[bytes, None]:

--- a/test/common/connector/test_redis_queue.py
+++ b/test/common/connector/test_redis_queue.py
@@ -28,7 +28,7 @@ class TestRedisQueue(unittest.TestCase):
 
     def setUp(self):
         self.connector = RedisQueueConnector(
-            fe_send_key="TEST_FE_SEND", be_send_key="TEST_BE_SEND",
+            send_key="TEST_SEND",
             host=self.REDIS_HOST, port=self.REDIS_PORT)
 
     def tearDown(self):

--- a/test/common/queue/test_redis.py
+++ b/test/common/queue/test_redis.py
@@ -19,7 +19,7 @@ class TestRedisQueue(unittest.TestCase):
         cls.REDIS_HOST = os.getenv(
             "REDIS_HOST", "redis-12259.c240.us-east-1-3.ec2.redns.redis-cloud.com")
         cls.REDIS_PORT = os.getenv("REDIS_PORT", "12259")
-        Logger.init(logging.DEBUG)
+        Logger.init(logging.DEBUG, is_file=False)
 
     @classmethod
     def tearDownClass(cls):

--- a/test/core/llm/test_llamacpp.py
+++ b/test/core/llm/test_llamacpp.py
@@ -11,14 +11,16 @@ from src.common.types import SessionCtx, MODELS_DIR
 from src.cmd.init import PromptInit
 import src.core.llm
 
+r"""
+python -m unittest test.core.llm.test_llamacpp.TestLLamacppLLM.test_have_special_char
+MODEL_TYPE=generate  python -m unittest test.core.llm.test_llamacpp.TestLLamacppLLM.test_generate
+MODEL_TYPE=generate STREAM=1 python -m unittest test.core.llm.test_llamacpp.TestLLamacppLLM.test_generate
+python -m unittest test.core.llm.test_llamacpp.TestLLamacppLLM.test_chat_completion
+STREAM=1 python -m unittest test.core.llm.test_llamacpp.TestLLamacppLLM.test_chat_completion
+"""
+
 
 class TestLLamacppLLM(unittest.TestCase):
-    r"""
-    MODEL_TYPE=generate  python -m unittest test.core.llm.test_llamacpp.TestLLamacppLLM.test_generate
-    MODEL_TYPE=generate STREAM=1 python -m unittest test.core.llm.test_llamacpp.TestLLamacppLLM.test_generate
-    python -m unittest test.core.llm.test_llamacpp.TestLLamacppLLM.test_chat_completion
-    STREAM=1 python -m unittest test.core.llm.test_llamacpp.TestLLamacppLLM.test_chat_completion
-    """
     @classmethod
     def setUpClass(cls):
         cls.llm_tag = os.getenv('LLM_TAG', "llm_llamacpp")
@@ -61,7 +63,7 @@ class TestLLamacppLLM(unittest.TestCase):
             self.assertGreater(len(item), 0)
 
     def test_have_special_char(self):
-        index = self.llm._have_special_char("你好,中国")
+        index = self.llm._have_special_char("""'你好',中国""")
         print(index)
         self.assertGreater(index, -1)
 

--- a/test/integration/test_tts_play.py
+++ b/test/integration/test_tts_play.py
@@ -1,0 +1,132 @@
+import os
+import logging
+import threading
+import traceback
+
+import unittest
+import uuid
+
+from src.common.connector.redis_queue import RedisQueueConnector
+from src.common.logger import Logger
+from src.common.session import Session
+from src.common.types import SessionCtx
+from src.common import interface
+from src.common.factory import EngineClass
+if os.getenv("INIT_TYPE", 'env') == 'yaml_config':
+    from src.cmd.init import YamlConfig as init
+else:
+    from src.cmd.init import Env as init
+
+r"""
+REDIS_PASSWORD=*** TTS_TAG=tts_g python -m unittest test.integration.test_tts_play.TestTTSPlay.test_tts
+
+REDIS_PASSWORD=*** TTS_TAG=tts_g python -m unittest test.integration.test_tts_play.TestTTSPlay.test_filter_special_chars
+"""
+
+
+class TestTTSPlay(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        Logger.init(logging.INFO, is_file=False, is_console=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def on_play_end(self, session: Session):
+        logging.info(f"play end with session.ctx {session.ctx}")
+
+    def on_play_chunk(self, session: Session, sub_chunk: bytes):
+        logging.info(
+            f"play chunk with session.ctx.state {session.ctx.state} sub_chunk_len {len(sub_chunk)}")
+
+    def setUp(self):
+        self.sid = uuid.uuid4()
+        self.session = Session(**SessionCtx(self.sid).__dict__)
+        self.tts: interface.ITts | EngineClass = init.initTTSEngine()
+        self.conn = RedisQueueConnector(
+            send_key=os.getenv("SEND_KEY", "SEND"),
+            host=os.getenv(
+                "REDIS_HOST",
+                "redis-12259.c240.us-east-1-3.ec2.redns.redis-cloud.com"),
+            port=os.getenv("REDIS_PORT", "12259"))
+
+        self.player = init.initPlayerEngine()
+        self.player.set_args(on_play_end=self.on_play_end)
+        self.player.set_args(on_play_chunk=self.on_play_chunk)
+        self.player.start(self.session)
+
+    def tearDown(self):
+        self.player.stop(self.session)
+        self.conn.close()
+
+    def test_filter_special_chars(self):
+        test_case = [
+            {"text": "这是个测试字符串", "expect": "这是个测试字符串"},
+            {"text": "这是个测试字符串？", "expect": "这是个测试字符串？"},
+            {"text": "这是个测试字符串？！？！」}", "expect": "这是个测试字符串？"},
+            {"text": "？", "expect": ""},
+            {"text": "【结束】", "expect": "【结束】"},
+            {"text": "\n\n【结束】", "expect": "【结束】"},
+            # {"text": "请问有什么问题或主题需要我提供信息或者帮助吗？"},
+            # {"text": "请告诉我您的需求，我会尽力为您提供最佳答案。"},
+            # {"text": "祝您好运！"},
+        ]
+        for item in test_case:
+            res = self.tts.filter_special_chars(item['text'])
+            print(f"res:{res}")
+            self.assertEqual(res, item['expect'])
+
+    def test_tts(self):
+        play_t = threading.Thread(target=self.loop_recv)
+        play_t.start()
+
+        send_t = threading.Thread(target=self.send)
+        send_t.start()
+
+        send_t.join()
+        play_t.join()
+
+    def send(self):
+        test_case = [
+            {"text": "你好！"},
+            {"text": "很高兴能帮助您。"},
+            {"text": "。!>}]"},
+            # {"text": "请问有什么问题或主题需要我提供信息或者帮助吗？"},
+            # {"text": "请告诉我您的需求，我会尽力为您提供最佳答案。"},
+            # {"text": "祝您好运！"},
+        ]
+        for item in test_case:
+            self.session.ctx.state["tts_text"] = item["text"]
+            audio_iter = self.tts.synthesize_sync(self.session)
+            for i, chunk in enumerate(audio_iter):
+                logging.info(f"synthesize audio {i} chunk {len(chunk)}")
+                if len(chunk) > 0:
+                    self.conn.send(("PLAY_FRAMES", chunk, self.session), 'be')
+        self.conn.send(("PLAY_FRAMES_DONE", "", self.session), 'be')
+
+    def loop_recv(self):
+        logging.info(f"start loop_recv with {self.player.TAG} ...")
+        while True:
+            try:
+                res = self.conn.recv('fe')
+                if res is None:
+                    continue
+
+                msg, recv_data, self.session = res
+                if msg is None or msg.lower() == "stop":
+                    break
+                logging.info(f"msg: {msg} recv_data_len: {len(recv_data)}")
+
+                if msg == "PLAY_FRAMES":
+                    self.session.ctx.state["tts_chunk"] = recv_data
+                    self.player.play_audio(self.session)
+                elif msg == "PLAY_FRAMES_DONE":
+                    self.player.stop(self.session)
+                    self.player.start(self.session)
+                    break
+                else:
+                    logging.warning(f"unsupport msg {msg}")
+            except Exception as ex:
+                ex_trace = traceback.format_exc()
+                logging.warning(f"loop_recv Exception {ex}, trace: {ex_trace}")

--- a/test/modules/speech/asr/test_whisper_asr.py
+++ b/test/modules/speech/asr/test_whisper_asr.py
@@ -87,7 +87,7 @@ class TestWhisperASR(unittest.TestCase):
                 self.asr.args.language = "en"
 
                 file_path = asyncio.run(save_audio_to_file(
-                    audio_frames, self.session.get_file_name(),
+                    audio_frames, self.session.get_record_audio_name(),
                     audio_dir=RECORDS_DIR))
                 self.asr.set_audio_data(file_path)
 


### PR DESCRIPTION
fix:
- remote-queue-chat with redis queue
- session 
- filter_special_chars for tts
- add `is_save_record` to save record  and `is_save_play_chunks` to save play chat round record; default False

run:
- fe: 
```
TTS_TAG=tts_edge \
  REDIS_PASSWORD=***  SEND_KEY=*** \
  RUN_OP=fe \
  RECORDER_TAG=rms_recorder \
  python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/fe_std_out.log

#or use wake word
TTS_TAG=tts_edge \
  REDIS_PASSWORD=*** SEND_KEY=*** \
  RUN_OP=fe \
  RECORDER_TAG=wakeword_rms_recorder \
  python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/fe_std_out.log
```
- be on cpu:
```
TQDM_DISABLE=True \
  ASR_TAG=whisper_faster_asr \
  ASR_MODEL_NAME_OR_PATH=./models/Systran/faster-whisper-base \
  REDIS_PASSWORD=*** SEND_KEY=*** \
  RUN_OP=be \
  TTS_TAG=tts_edge \
  LLM_MODEL_NAME=qwen \
  LLM_MODEL_PATH=./models/qwen2-1_5b-instruct-q8_0.gguf \
  python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/be_std_out.log
```

- be on gpu with local asr -> llm -> tts:
```
TQDM_DISABLE=True \
  ASR_TAG=whisper_faster_asr \
  ASR_MODEL_NAME_OR_PATH=./models/Systran/faster-whisper-base \
  REDIS_PASSWORD=*** SEND_KEY=*** \
  RUN_OP=be \
  TTS_TAG=tts_coqui \
  LLM_MODEL_NAME=qwen \
  LLM_MODEL_PATH=./models/qwen2-1_5b-instruct-q8_0.gguf \
  python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/be_std_out.log
```