### PR TITLE
feat: integrate cosy_voice_tts & fix: postprocess_tts_wave_int16 bytes stream

### DIFF
--- a/demo/asr_sense_voice.py
+++ b/demo/asr_sense_voice.py
@@ -9,7 +9,7 @@ print(m, kwargs)
 
 start = time.time()
 res = m.inference(
-    #data_in="https://isv-data.oss-cn-hangzhou.aliyuncs.com/ics/MaaS/ASR/test_audio/asr_example_zh.wav",
+    # data_in="https://isv-data.oss-cn-hangzhou.aliyuncs.com/ics/MaaS/ASR/test_audio/asr_example_zh.wav",
     data_in="./records/asr_example_zh.wav",
     language="auto",  # "zn", "en", "yue", "ja", "ko", "nospeech"
     use_itn=False,

--- a/src/cmd/init.py
+++ b/src/cmd/init.py
@@ -17,6 +17,7 @@ from src.common.types import (
     WebRTCSileroVADArgs,
     AudioRecoderArgs,
     VADRecoderArgs,
+    CosyVoiceTTSArgs,
 )
 # need import engine class -> EngineClass.__subclasses__
 import src.modules.speech
@@ -48,6 +49,12 @@ class PlayStreamInit():
             "sample_width": 2,
         },
         'tts_g': {
+            "format": pyaudio.paInt16,
+            "channels": 1,
+            "rate": 22050,
+            "sample_width": 2,
+        },
+        'tts_cosy_voice': {
             "format": pyaudio.paInt16,
             "channels": 1,
             "rate": 22050,
@@ -194,6 +201,11 @@ class Env(PromptInit, PlayStreamInit):
         return engine
 
     @staticmethod
+    def get_tts_cosy_voice_args() -> dict:
+        kwargs = CosyVoiceTTSArgs().__dict__
+        return kwargs
+
+    @staticmethod
     def get_tts_coqui_args() -> dict:
         kwargs = {}
         kwargs["model_path"] = os.getenv('TTS_MODEL_PATH', os.path.join(
@@ -291,6 +303,7 @@ class Env(PromptInit, PlayStreamInit):
     # TAG : config
     map_config_func = {
         'tts_coqui': get_tts_coqui_args,
+        'tts_cosy_voice': get_tts_cosy_voice_args,
         'tts_chat': get_tts_chat_args,
         'tts_edge': get_tts_edge_args,
         'tts_g': get_tts_g_args,

--- a/src/cmd/remote-queue-chat/generate_audio2audio.py
+++ b/src/cmd/remote-queue-chat/generate_audio2audio.py
@@ -12,12 +12,31 @@ from src.common.logger import Logger
 
 r"""
 
-REDIS_PASSWORD=*** RUN_OP=fe python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/fe_std_out.log
-REDIS_PASSWORD=*** RUN_OP=be TQDM_DISABLE=True python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/be_std_out.log
+REDIS_PASSWORD=$redis_pwd RUN_OP=fe python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/fe_std_out.log
+REDIS_PASSWORD=$redis_pwd RUN_OP=be TQDM_DISABLE=True python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/be_std_out.log
 
 # with wakeword
-REDIS_PASSWORD=*** RUN_OP=fe RECORDER_TAG=wakeword_rms_recorder python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/fe_std_out.log
-REDIS_PASSWORD=*** RUN_OP=be TQDM_DISABLE=True python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/be_std_out.log
+REDIS_PASSWORD=$redis_pwd RUN_OP=fe RECORDER_TAG=wakeword_rms_recorder python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/fe_std_out.log
+REDIS_PASSWORD=$redis_pwd RUN_OP=be TQDM_DISABLE=True python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/be_std_out.log
+
+TTS_TAG=tts_cosy_voice \
+  REDIS_PASSWORD=$redis_pwd \
+  RUN_OP=fe \
+  RECORDER_TAG=wakeword_rms_recorder \
+  python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/fe_std_out.log
+
+# sense_voice (asr) -> qwen (llm) -> cosy_voice (tts)
+!RUN_OP=be \
+  TQDM_DISABLE=True \
+  REDIS_PASSWORD=$redis_pwd \
+  ASR_TAG=sense_voice_asr \
+  ASR_LANG=zn \
+  N_GPU_LAYERS=33 FLASH_ATTN=1 \
+  LLM_MODEL_NAME=qwen \
+  LLM_MODEL_PATH=./models/qwen1_5-7b-chat-q8_0.gguf \
+  ASR_MODEL_NAME_OR_PATH=./models/FunAudioLLM/SenseVoiceSmall \
+  TTS_TAG=tts_cosy_voice \
+  python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/be_std_out.log
 """
 
 

--- a/src/common/types.py
+++ b/src/common/types.py
@@ -397,4 +397,4 @@ class CosyVoiceTTSArgs:
     reference_audio_path: str = ""  # 16k sample rate audio file for base pt model
     instruct_text: str = ""  # use with instruct model
     spk_id: str = ""  # use with sft and instruct model
-    pass
+    language: str = "zh"

--- a/src/common/utils/audio_utils.py
+++ b/src/common/utils/audio_utils.py
@@ -85,9 +85,21 @@ def torchTensor2bytes(tensor: torch.Tensor) -> bytearray:
     return npArray2bytes(np_arr)
 
 
+def postprocess_tts_wave_int16(chunk: torch.Tensor | list) -> bytes:
+    r"""
+    Post process the output waveform with numpy.int16 to bytes
+    """
+    if isinstance(chunk, list):
+        chunk = torch.cat(chunk, dim=0)
+    chunk = chunk.clone().detach().cpu().numpy()
+    chunk = chunk * (2 ** 15)
+    chunk = chunk.astype(np.int16)
+    return chunk.tobytes()
+
+
 def postprocess_tts_wave(chunk: torch.Tensor | list) -> bytes:
     r"""
-    Post process the output waveform
+    Post process the output waveform with numpy.float32 to bytes
     """
     if isinstance(chunk, list):
         chunk = torch.cat(chunk, dim=0)

--- a/src/modules/speech/tts/__init__.py
+++ b/src/modules/speech/tts/__init__.py
@@ -3,4 +3,5 @@ from . import chat_tts
 from . import pyttsx3_tts
 from . import g_tts
 from . import edge_tts
+from . import cosy_voice_tts
 # from . import openai_tts

--- a/src/modules/speech/tts/coqui_tts.py
+++ b/src/modules/speech/tts/coqui_tts.py
@@ -7,7 +7,7 @@ import random
 import torch
 import pyaudio
 import numpy as np
-# import torchaudio
+import torchaudio
 
 from src.common.device_cuda import CUDAInfo
 from src.common.interface import ITts
@@ -92,7 +92,10 @@ class CoquiTTS(BaseTTS, ITts):
                 speed=self.args.tts_speed,
                 num_beams=self.args.tts_num_beams,
             )
+
             tensor_wave = torch.tensor(out["wav"]).unsqueeze(0).cpu()
+            logging.debug(
+                f"{self.TAG} inference out tensor {torch.tensor(out['wav']).shape}, tensor_wave: {tensor_wave.shape}")
             # torchaudio.save("records/tts_coqui_infer_zh_test.wav", tensor_wave, 24000)
 
             res = postprocess_tts_wave(tensor_wave)

--- a/src/modules/speech/tts/cosy_voice_tts.py
+++ b/src/modules/speech/tts/cosy_voice_tts.py
@@ -3,11 +3,15 @@ import random
 import os
 from typing import AsyncGenerator
 
+import torchaudio
+import numpy as np
+import pyaudio
+
 
 from src.common.interface import ITts
 from src.common.session import Session
-from src.common.types import CosyVoiceTTSArgs, RATE
-from src.common.utils.audio_utils import postprocess_tts_wave
+from src.common.types import CosyVoiceTTSArgs, RATE, RECORDS_DIR
+from src.common.utils.audio_utils import postprocess_tts_wave_int16
 from .base import BaseTTS
 
 
@@ -22,6 +26,9 @@ class CosyVoiceTTS(BaseTTS, ITts):
         return {**CosyVoiceTTSArgs().__dict__, **kwargs}
 
     def __init__(self, **args) -> None:
+        import sys
+        sys.path.insert(1, os.path.join(sys.path[0], 'deps/CosyVoice'))
+        sys.path.insert(2, os.path.join(sys.path[0], 'deps/CosyVoice/third_party/Matcha-TTS'))
         from deps.CosyVoice.cosyvoice.cli.cosyvoice import CosyVoice
         from deps.CosyVoice.cosyvoice.utils.file_utils import load_wav
         self.args = CosyVoiceTTSArgs(**args)
@@ -32,9 +39,29 @@ class CosyVoiceTTS(BaseTTS, ITts):
         self.reference_audio = None
         if os.path.exists(self.args.reference_audio_path):
             self.reference_audio = load_wav(self.args.reference_audio_path, RATE)
+        for name, model in {
+            "llm_model": self.model.model.llm,
+            "flow_model": self.model.model.flow,
+            "hift_model": self.model.model.hift,
+        }.items():
+            model_million_params = sum(p.numel() for p in model.parameters()) / 1e6
+            logging.debug(f"{name} {model} {model_million_params}M parameters")
 
     def get_voices(self):
-        return self.model.list_avaliable_spks()
+        spk_ids = []
+        for spk_id in self.model.list_avaliable_spks():
+            if self.args.language == "zh" and "中" in spk_id:
+                spk_ids.append(spk_id)
+            if self.args.language == "zh_yue" and "粤" in spk_id:
+                spk_ids.append(spk_id)
+            if self.args.language == "en" and "英" in spk_id:
+                spk_ids.append(spk_id)
+            if self.args.language == "jp" and "日" in spk_id:
+                spk_ids.append(spk_id)
+            if self.args.language == "ko" and "韩" in spk_id:
+                spk_ids.append(spk_id)
+
+        return spk_ids
 
     async def _inference(self, session: Session, text: str) -> AsyncGenerator[bytes, None]:
         if self.reference_audio is None:
@@ -49,6 +76,8 @@ class CosyVoiceTTS(BaseTTS, ITts):
             else:
                 output = self.model.inference_zero_shot(
                     text, self.args.instruct_text, self.reference_audio)
-        if hasattr(output, 'tts_speech'):
-            res = postprocess_tts_wave(output['tts_speech'])
+        if 'tts_speech' in output:
+            # torchaudio.save(os.path.join(RECORDS_DIR, f'{self.TAG}_speech.wav'),
+            #                output['tts_speech'], 22050)
+            res = postprocess_tts_wave_int16(output['tts_speech'])
             yield res

--- a/test/modules/speech/tts/test_coqui.py
+++ b/test/modules/speech/tts/test_coqui.py
@@ -24,7 +24,7 @@ class TestCoquiTTS(unittest.TestCase):
     def setUpClass(cls):
         cls.tts_tag = os.getenv('TTS_TAG', "tts_coqui")
         cls.tts_text = os.getenv(
-            'TTS_TEXT', "你好！有什么可以帮助你的吗？请描述一下您的问题或需求。")
+            'TTS_TEXT', "你好！")
         cls.stream = os.getenv('STREAM', "")
         cls.conf_file = os.getenv(
             'CONF_FILE', os.path.join(MODELS_DIR, "coqui/XTTS-v2/config.json"))
@@ -46,7 +46,33 @@ class TestCoquiTTS(unittest.TestCase):
         self.tts: CoquiTTS = EngineFactory.get_engine_by_tag(
             EngineClass, self.tts_tag, **kwargs)
         self.session = Session(**SessionCtx("test_tts_client_id").__dict__)
+        self.pyaudio_instance = None
+        self.audio_stream = None
 
+    def tearDown(self):
+        self.audio_stream and self.audio_stream.stop_stream()
+        self.audio_stream and self.audio_stream.close()
+        self.pyaudio_instance and self.pyaudio_instance.terminate()
+
+    def test_synthesize(self):
+        stream_info = self.tts.get_stream_info()
+        self.session.ctx.state["tts_text"] = self.tts_text
+        print(self.session.ctx)
+        iter = self.tts.synthesize_sync(self.session)
+        res = bytearray()
+        for i, chunk in enumerate(iter):
+            print(i, len(chunk))
+            res.extend(chunk)
+        path = asyncio.run(save_audio_to_file(
+            res,
+            f"test_{self.tts.TAG}.wav",
+            sample_rate=stream_info["rate"],
+            sample_width=stream_info["sample_width"],
+            channles=stream_info["channels"],
+        ))
+        print(path)
+
+    def test_synthesize_speak(self):
         stream_info = self.tts.get_stream_info()
         self.pyaudio_instance = pyaudio.PyAudio()
         self.audio_stream = self.pyaudio_instance.open(
@@ -56,12 +82,6 @@ class TestCoquiTTS(unittest.TestCase):
             output_device_index=None,
             output=True)
 
-    def tearDown(self):
-        self.audio_stream.stop_stream()
-        self.audio_stream.close()
-        self.pyaudio_instance.terminate()
-
-    def test_synthesize(self):
         self.session.ctx.state["tts_text"] = self.tts_text
         print(self.session.ctx)
         self.tts.args.tts_stream = bool(self.stream)
@@ -69,7 +89,6 @@ class TestCoquiTTS(unittest.TestCase):
         sub_chunk_size = 1024
         for i, chunk in enumerate(iter):
             print(f"get {i} chunk {len(chunk)}")
-            self.assertGreater(len(chunk), 0)
             if len(chunk) / sub_chunk_size < 100:
                 self.audio_stream.write(chunk)
                 continue


### PR DESCRIPTION
feat: 
- integrate cosy_voice_tts , use this env config case to run:
```
# fe
TTS_TAG=tts_cosy_voice \
  REDIS_PASSWORD=$redis_pwd \
  RUN_OP=fe \
  RECORDER_TAG=wakeword_rms_recorder \
  python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/fe_std_out.log

# be
# sense_voice (asr) -> qwen (llm) -> cosy_voice (tts)
RUN_OP=be \
  TQDM_DISABLE=True \
  REDIS_PASSWORD=$redis_pwd \
  ASR_TAG=sense_voice_asr \
  ASR_LANG=zn \
  N_GPU_LAYERS=33 FLASH_ATTN=1 \
  LLM_MODEL_NAME=qwen \
  LLM_MODEL_PATH=./models/qwen1_5-7b-chat-q8_0.gguf \
  ASR_MODEL_NAME_OR_PATH=./models/FunAudioLLM/SenseVoiceSmall \
  TTS_TAG=tts_cosy_voice \
  python -m src.cmd.remote-queue-chat.generate_audio2audio > ./log/be_std_out.log
```
fix: 
- postprocess_tts_wave_int16 bytes stream